### PR TITLE
Adding system call error check and log

### DIFF
--- a/htdocs/404.php
+++ b/htdocs/404.php
@@ -55,6 +55,7 @@ if ($is_media) {
             $dir = dirname($dest);
             if (!is_dir($dir)) {
                 if (!@mkdir($dir, 0755, true)) {
+                    error_log("Can't create dir ".$dir);
                     exit("Can't create dir ".$dir);
                 }
             }
@@ -69,9 +70,16 @@ if ($is_media) {
             $target = DOCROOT.$media->get_public_path();
             $dir = dirname($target);
             if (!is_dir($dir)) {
-                mkdir($dir, 0755, true);
+                if(!@mkdir($dir, 0755, true)) {
+                    error_log("Can't create dir ".$dir);
+                    exit("Can't create dir ".$dir);
+                }
             }
-            symlink(Nos\Tools_File::relativePath(dirname($target), $source), $target);
+            if(!@symlink(Nos\Tools_File::relativePath(dirname($target),
+                $source), $target)) {
+                error_log("Can't symlink in ".$source);
+                exit("Can't symlink in ".$source);
+            }
             $send_file = $source;
         }
     }


### PR DESCRIPTION
I found myself subject to some error in the  `404.php` file. I eventually saw there were no check on `mkdir` system call for `media` when not resized. 

Also added calls to `error_log` to actually send the error to the apache log. Seems that the exit message is lost for me (did not saw it anywhere, neither in the back-office nor the logs).
