### PR TITLE
$config should be an array because of \Arr::merge

### DIFF
--- a/framework/classes/fuel/orm/model.php
+++ b/framework/classes/fuel/orm/model.php
@@ -297,7 +297,7 @@ class Model extends \Orm\Model
             }
 
             \Config::load($application.'::'.$file_name, true);
-            $config = \Config::get($application.'::'.$file_name);
+            $config = \Config::get($application.'::'.$file_name, array();
             \Config::load(APPPATH.'metadata'.DS.'app_dependencies.php', 'data::app_dependencies');
             $dependencies = \Config::get('data::app_dependencies', array());
 


### PR DESCRIPTION
If the original model does not have a config file whereas the extended one does, 
the \Arr::merge would raise an error without the default "array()" value.
