### PR TITLE
Fixed wrong order for $params merge

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -43,12 +43,12 @@ class FrontCache
         }
 
         $params = \Arr::merge(
-            $params,
             array(
                 'callback_args' => array(),
                 'duration' => \Config::get('novius-os.cache_duration_function', 10),
                 'controller' => null,
-            )
+            ),
+            $params
         );
 
         $cache = new static($path);


### PR DESCRIPTION
Function's params should override default params
