### PR TITLE
small fix on front

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -454,7 +454,13 @@ class Controller_Front extends Controller
 
         $footer = array();
         $this->_js_footer = array_unique($this->_js_footer, SORT_REGULAR);
-        $this->_js_footer = array_diff($this->_js_footer, $this->_js_header);
+        for ($i = 0; $i < count($this->_js_footer); $i++) {
+            for ($j = 0; $j < count($this->_js_header); $j++) {
+                if ($this->_js_footer[$i] === $this->_js_header[$j]) {
+                    array_splice($this->_js_footer, $i, 1);
+                }
+            }
+        }
         foreach ($this->_js_footer as $js) {
             if (is_array($js) && isset($js['inline']) && $js['inline'] && isset($js['js'])) {
                 $footer[] = '<script type="text/javascript">'.$js['js'].'</script>';


### PR DESCRIPTION
js_footer and js_header can contain other things than string, such as array for inline javascript...

Therefore array_diff doesn't work properly on this case and will throw warnings for php 5.4.

I found a solution working on my project but I am not sure that this is the best solution.
