### PR TITLE
Wrong variable test in media.model.php

### DIFF
--- a/framework/applications/noviusos_media/classes/model/media.model.php
+++ b/framework/applications/noviusos_media/classes/model/media.model.php
@@ -133,7 +133,7 @@ class Model_Media extends \Nos\Orm\Model
         if (!$this->is_image()) {
             return false;
         }
-        if (!empty($max_width) || !empty($params['max_height'])) {
+        if (!empty($max_width) || !empty($max_height)) {
             list($width, $height, $ratio) = \Nos\Tools_Image::calculate_ratio($this->media_width, $this->media_height, $max_width, $max_height);
             $src = $this->get_public_path_resized($max_width, $max_height);
         } else {


### PR DESCRIPTION
The variable $params['max_height'] isn't defined whereas the variable $max_height isn't tested.
I suppose this is a mistake and that this is $max_height which must be tested.
