### PR TITLE
- Adding a config novius-os.cache for use of cache on front, by default ...

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -66,7 +66,7 @@ class Controller_Front extends Controller
         if (\Input::method() == 'POST' || $this->_is_preview) {
             $no_cache = true;
         } else {
-            $no_cache = \Fuel::$env === \Fuel::DEVELOPMENT && \Input::get('_cache', 0) != 1;
+            $no_cache = !\Input::get('_cache', \Config::get('novius-os.cache', true));
         }
 
         \Event::trigger('front.start');
@@ -77,7 +77,7 @@ class Controller_Front extends Controller
         $cache = FrontCache::forge('pages'.DS.$cache_path);
 
         try {
-            if (\Input::method() == 'POST' || $this->_is_preview) {
+            if ($no_cache) {
                 throw new CacheNotFoundException();
             }
 

--- a/framework/config/config.php
+++ b/framework/config/config.php
@@ -221,8 +221,9 @@ return array(
     ),
 
     'novius-os' => array(
-        'cache_duration_page' => 5,
-        'cache_duration_function' => 10,
+        'cache' => \Fuel::$env !== \Fuel::DEVELOPMENT,
+        'cache_duration_page' => 60,
+        'cache_duration_function' => 60,
 
         'locales' => array(
             'en_GB' => array(


### PR DESCRIPTION
...true except in development
- Setting configs novius-os.cache_duration_page and novius-os.cache_duration_function at 60 by default
- Bugfix : controller front, POST and _preview use cache
