### PR TITLE
Feature : requires key

### DIFF
--- a/framework/applications/noviusos_appmanager/lang/fr/common.lang.php
+++ b/framework/applications/noviusos_appmanager/lang/fr/common.lang.php
@@ -42,7 +42,7 @@ return array(
     'Up-to-date' => 'À jour',
 
     #: views/admin/app_manager.view.php:70
-    'Uninstall' => 'Désintaller',
+    'Uninstall' => 'Désinstaller',
 
     #: views/admin/app_manager.view.php:82
     #: views/admin/app_manager.view.php:120

--- a/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
+++ b/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
@@ -78,16 +78,12 @@ foreach ($installed as $app) {
             $dependent = \Nos\Application::forge($dependent)->get_name();
         }
         if (count($dependents) == 1) {
-            echo strtr(__('Required by the "{{application}}" application.'), array('{{application}}' => $dependents[0]));
+            echo strtr(__('Cannot be uninstalled. Uninstall ‘{{application}}’ first.'), array('{{application}}' => $dependents[0]));
         } else {
-            echo  __('Required by other installed applications.').
+            echo  __('Cannot be uninstalled. Uninstall <a>these applications</a> first.').
                 \View::forge('nos::admin/tooltip', array(
                     'title' => '',
-                    'content' => strtr(__('Required by the following applications: {{applications}}'),
-                        array(
-                            '{{applications}}' => '<br/><br/>- '.implode('<br/>- ', $dependents)
-                        )
-                    ),
+                    'content' => '<ul><li>' . implode('</li><li>', $dependents) . '</li></ul>',
                     'options' => array(
                     ),
                 ), false);
@@ -136,16 +132,12 @@ foreach ($others as $app) {
         // @note: we can't get application names here since they don't exist therefore there aren't any metadata
         $unavailable_applications = $app->applicationsRequiredAndUnavailable();
         if (count($unavailable_applications) == 1) {
-            echo strtr(__('Application "{{application}}" required.'), array('{{application}}' => $unavailable_applications[0]));
+            echo strtr(__('Cannot be installed. Install ‘{{application}}’ first.'), array('{{application}}' => $unavailable_applications[0]));
         } else {
-            echo __('Unavailable applications required.').
+            echo __('Cannot be installed. Install <a>these applications</a> first.').
                 \View::forge('nos::admin/tooltip', array(
                     'title' => '',
-                    'content' => strtr(__('The following applications are required but unavailable: {{applications}}'),
-                        array(
-                            '{{applications}}' => '<br/><br/>- '.implode('<br/>- ', $unavailable_applications)
-                        )
-                    ),
+                    'content' => '<ul><li>' . implode('</li><li>', $unavailable_applications) . '</li></ul>',
                     'options' => array(
                     ),
                 ), false);

--- a/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
+++ b/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
@@ -27,6 +27,9 @@ Nos\I18n::current_dictionary('noviusos_appmanager::common');
         .app_manager .app_list_available {
             width : 600px;
         }
+        .app_manager label.tooltip {
+            font-weight: bold;
+        }
     </style>
 
     <div class="col c1"></div>
@@ -81,13 +84,10 @@ foreach ($installed as $app) {
         if (count($dependents) == 1) {
             echo strtr(__('Cannot be uninstalled. Uninstall ‘{{application}}’ first.'), array('{{application}}' => $dependents[0]));
         } else {
-            echo  __('Cannot be uninstalled. Uninstall <a>these applications</a> first.').
-                \View::forge('nos::admin/tooltip', array(
-                    'title' => '',
-                    'content' => '<ul><li>' . implode('</li><li>', $dependents) . '</li></ul>',
-                    'options' => array(
-                    ),
-                ), false);
+            echo  preg_replace('`<a>(.*)</a>`',
+                render('noviusos_appmanager::admin/applications_tooltip', array('applications' => $dependents)),
+                __('Cannot be uninstalled. Uninstall <a>these applications</a> first.')
+            );
         }
     }
         ?>
@@ -135,13 +135,10 @@ foreach ($others as $app) {
         if (count($unavailable_applications) == 1) {
             echo strtr(__('Cannot be installed. Install ‘{{application}}’ first.'), array('{{application}}' => $unavailable_applications[0]));
         } else {
-            echo __('Cannot be installed. Install <a>these applications</a> first.').
-                \View::forge('nos::admin/tooltip', array(
-                    'title' => '',
-                    'content' => '<ul><li>' . implode('</li><li>', $unavailable_applications) . '</li></ul>',
-                    'options' => array(
-                    ),
-                ), false);
+            echo  preg_replace('`<a>(.*)</a>`',
+                render('noviusos_appmanager::admin/applications_tooltip', array('applications' => $unavailable_applications)),
+                __('Cannot be installed. Install <a>these applications</a> first.')
+            );
         }
 
 

--- a/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
+++ b/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
@@ -77,6 +77,7 @@ foreach ($installed as $app) {
         foreach ($dependents as &$dependent) {
             $dependent = \Nos\Application::forge($dependent)->get_name();
         }
+        unset($dependent);
         if (count($dependents) == 1) {
             echo strtr(__('Required by the "{{application}}" application.'), array('{{application}}' => $dependents[0]));
         } else {

--- a/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
+++ b/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
@@ -67,7 +67,33 @@ foreach ($installed as $app) {
     ?>
                         </td>
                         <td>
+    <?php
+    if ($app->canUninstall()) {
+        ?>
                             <a href="#" data-app="<?= htmlspecialchars(\Format::forge(array('name' => $app->folder, 'action' => 'remove'))->to_json()) ?>" onclick="return false;"><button data-icon="arrowthick-1-s"><?= __('Uninstall') ?></button></a>
+    <?php
+    } else {
+        $dependents = $app->installedDependentApplications();
+        foreach ($dependents as &$dependent) {
+            $dependent = \Nos\Application::forge($dependent)->get_name();
+        }
+        if (count($dependents) == 1) {
+            echo strtr(__('Required by the "{{application}}" application.'), array('{{application}}' => $dependents[0]));
+        } else {
+            echo  __('Required by other installed applications.').
+                \View::forge('nos::admin/tooltip', array(
+                    'title' => '',
+                    'content' => strtr(__('Required by the following applications: {{applications}}'),
+                        array(
+                            '{{applications}}' => '<br/><br/>- '.implode('<br/>- ', $dependents)
+                        )
+                    ),
+                    'options' => array(
+                    ),
+                ), false);
+        }
+    }
+        ?>
                         </td>
                     </tr>
     <?php
@@ -92,6 +118,7 @@ if (empty($installed)) {
 <?php
 foreach ($others as $app) {
     $metadata = $app->getRealMetadata();
+    $can_install = $app->canInstall();
     ?>
                     <tr>
                         <td><?= e($app->get_name_translated()) ?> </td>
@@ -101,10 +128,30 @@ foreach ($others as $app) {
         ?>
                             <em><?php echo __('No metadata found') ?>.</em>
         <?php
-    } else {
+    } else if ($can_install) {
         ?>
                              <a href="#" data-app="<?= htmlspecialchars(\Format::forge(array('name' => $app->folder, 'action' => 'add'))->to_json()) ?>" onclick="return false;"><button data-icon="arrowthick-1-n"><?= __('Install') ?></button></a></td>
         <?php
+    } else {
+        // @note: we can't get application names here since they don't exist therefore there aren't any metadata
+        $unavailable_applications = $app->applicationsRequiredAndUnavailable();
+        if (count($unavailable_applications) == 1) {
+            echo strtr(__('Application "{{application}}" required.'), array('{{application}}' => $unavailable_applications[0]));
+        } else {
+            echo __('Unavailable applications required.').
+                \View::forge('nos::admin/tooltip', array(
+                    'title' => '',
+                    'content' => strtr(__('The following applications are required but unavailable: {{applications}}'),
+                        array(
+                            '{{applications}}' => '<br/><br/>- '.implode('<br/>- ', $unavailable_applications)
+                        )
+                    ),
+                    'options' => array(
+                    ),
+                ), false);
+        }
+
+
     }
     ?>
                     </tr>
@@ -156,17 +203,23 @@ if ($local->is_dirty()) {
                         labelDisplay: false
                     });
 
-                    $(".app_list_installed table").wijgrid({
+                    $(".app_list_available table, .app_list_installed table").wijgrid({
                         rendered: function(args) {
                             $(args.target).closest('.wijmo-wijgrid').find('thead').hide();
-                        },
-                        selectionMode: 'none',
-                        highlightCurrentCell: false
-                    });
 
-                    $(".app_list_available table").wijgrid({
-                        rendered: function(args) {
-                            $(args.target).closest('.wijmo-wijgrid').find('thead').hide();
+                            var $tooltip = $(args.target).find('.tooltip');
+                            $tooltip.wijtooltip({
+                                showCallout: false,
+                                calloutFilled : true,
+                                closeBehavior: 'sticky',
+                                position : {
+                                    my : 'center top',
+                                    at : 'center bottom',
+                                    offset : '0 0'
+                                },
+                                triggers : 'click',
+                                content : $tooltip.find('div.content').html()
+                            });
                         },
                         selectionMode: 'none',
                         highlightCurrentCell: false
@@ -190,6 +243,7 @@ if ($local->is_dirty()) {
                             }
                         });
                     })
+
 
 <?php
 $flash = \Session::get_flash('notification.plugins');

--- a/framework/applications/noviusos_appmanager/views/admin/applications_tooltip.view.php
+++ b/framework/applications/noviusos_appmanager/views/admin/applications_tooltip.view.php
@@ -1,0 +1,10 @@
+<label class="tooltip">
+    $1
+    <div class="content">
+        <ul>
+            <li>
+                <?= implode('</li><li>', $applications) ?>
+            </li>
+        </ul>
+    </div>
+</label>

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -283,7 +283,7 @@ class Application
     public static function applicationRequiredFromMetadata($metadata)
     {
         $requires = isset($metadata['requires']) ? $metadata['requires'] :
-            (isset($metadata['extend']) ? $metadata['extend'] : array());
+            (isset($metadata['extends']) ? $metadata['extends'] : array());
 
         if ($requires && is_string($requires)) {
             $requires = array($requires);

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -10,8 +10,6 @@
 
 namespace Nos;
 
-use Oil\Exception;
-
 class Application
 {
     protected static $repositories;
@@ -345,7 +343,7 @@ class Application
     {
         if (!$this->canInstall()) {
             throw new \Exception('Application '.$this->folder.
-                ' can\'t be installed because it needs the following applications: '.implode(', ',
+                ' can\'t be installed because it requires the following applications: '.implode(', ',
                 $this->applicationsRequiredAndUnavailable()).'.');
         }
         $this->installRequiredApplications($add_permission);
@@ -393,7 +391,7 @@ class Application
         if (!$this->canUninstall()) {
             $dependents = $this->installedDependentApplications();
             throw new \Exception('Application '.$this->folder.
-                ' can\'t be uninstalled because it needs the following applications: '.implode(', ', $dependents).'.');
+                ' can\'t be uninstalled because it is required by the following applications: '.implode(', ', $dependents).'.');
         }
         $old_metadata = \Arr::get(static::$rawAppInstalled, $this->folder);
         $new_metadata = array();

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -282,14 +282,13 @@ class Application
 
     public static function applicationRequiredFromMetadata($metadata)
     {
-        $required = array();
-        if (isset($metadata['requires'])) {
-            $required = $metadata['requires'];
-            if (is_string($required)) {
-                $required = array($required);
-            }
+        $requires = isset($metadata['requires']) ? $metadata['requires'] :
+            (isset($metadata['extend']) ? $metadata['extend'] : array());
+
+        if ($requires && is_string($requires)) {
+            $requires = array($requires);
         }
-        return $required;
+        return $requires;
     }
 
     public function applicationsRequiredAndNotInstalled()


### PR DESCRIPTION
This pull request adds support for the `requires` key in the metadata. Here are precise specifications:
- value can be a string or an array. If it is a string, it will be considered as a array with a single element.
- Application can now require other application. This has two implications :
  - When the user installs an application, the core will try to install all required applications. If some of these applications don't exist, installation is judged impossible.
  - It is impossible to uninstall an application if other application requires it.
- If the `requires` key is not defined but the `extend` key is, the core considers that the application requires the one it is extending.
- The application manager interface has been improved to manage this `requires` key
