### PR TITLE
Feature : improved extends

### DIFF
--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -403,27 +403,35 @@ class Application
             }
         }
 
-        $old_dependency = \Arr::get($old_metadata, 'extends', '');
-        $new_dependency = \Arr::get($new_metadata, 'extends', '');
+        $old_dependency = static::extendsToDependency(\Arr::get($old_metadata, 'extends', null));
+        $new_dependency = static::extendsToDependency(\Arr::get($new_metadata, 'extends', null));
 
-        if ($old_dependency != $new_dependency) {
-            // Add new dependency
-            if ($new_dependency != '') {
-                if (empty($config['app_dependencies'][$new_dependency])) {
-                    $config['app_dependencies'][$new_dependency] = array();
-                }
-                $config['app_dependencies'][$new_dependency][] = $this->folder;
-            }
-
+        if ($old_dependency !== $new_dependency) {
             // Remove old dependency
-            if (!empty($config['app_dependencies'][$old_dependency])) {
-                foreach (array_keys($config['app_dependencies'][$old_dependency], $this->folder) as $key) {
-                    unset($config['app_dependencies'][$old_dependency][$key]);
-                }
-            }
+            unset($config['app_dependencies'][$old_dependency['application']][$this->folder]);
+            // Set new dependency
+            $config['app_dependencies'][$new_dependency['application']][$this->folder] = $new_dependency;
         }
 
         return $config;
+    }
+
+    protected static function extendsToDependency($extends)
+    {
+        if ($extends === null) {
+            return $extends;
+        }
+        if (!is_array($extends)) {
+            $extends = array(
+                'application' => $extends
+            );
+        }
+
+        if (!isset($extends['extend_configuration'])) {
+            $extends['extend_configuration'] = true;
+        }
+
+        return $extends;
     }
 
     protected function save_config($config)

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -515,14 +515,16 @@ class Application
             }
         }
 
-        $old_dependency = \Arr::get($old_metadata, 'extends', null);
+        $old_dependency = static::extendsToDependency(\Arr::get($old_metadata, 'extends', null));
         $new_dependency = static::extendsToDependency(\Arr::get($new_metadata, 'extends', null));
 
         if ($old_dependency !== $new_dependency) {
             // Remove old dependency
             unset($config['app_dependencies'][$old_dependency['application']][$this->folder]);
-            // Set new dependency if not null
-            if ($new_dependency !== null) {
+            // Set new dependency
+            if ($new_dependency === null) {
+                unset($config['app_dependencies'][$new_dependency['application']][$this->folder]);
+            } else {
                 $config['app_dependencies'][$new_dependency['application']][$this->folder] = $new_dependency;
             }
         }

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -282,8 +282,13 @@ class Application
 
     public static function applicationRequiredFromMetadata($metadata)
     {
-        $requires = isset($metadata['requires']) ? $metadata['requires'] :
-            (isset($metadata['extends']) ? $metadata['extends'] : array());
+        $requires = array();
+        if (isset($metadata['requires'])) {
+            $requires = $metadata['requires'];
+        } else if (isset($metadata['extends'])) {
+            $requires = static::extendsToDependency($metadata['extends']);
+            $requires = $requires['application'];
+        }
 
         if ($requires && is_string($requires)) {
             $requires = array($requires);
@@ -510,14 +515,16 @@ class Application
             }
         }
 
-        $old_dependency = static::extendsToDependency(\Arr::get($old_metadata, 'extends', null));
+        $old_dependency = \Arr::get($old_metadata, 'extends', null);
         $new_dependency = static::extendsToDependency(\Arr::get($new_metadata, 'extends', null));
 
         if ($old_dependency !== $new_dependency) {
             // Remove old dependency
             unset($config['app_dependencies'][$old_dependency['application']][$this->folder]);
-            // Set new dependency
-            $config['app_dependencies'][$new_dependency['application']][$this->folder] = $new_dependency;
+            // Set new dependency if not null
+            if ($new_dependency !== null) {
+                $config['app_dependencies'][$new_dependency['application']][$this->folder] = $new_dependency;
+            }
         }
 
         return $config;

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -537,7 +537,7 @@ class Application
         }
         if (!is_array($extends)) {
             $extends = array(
-                'application' => $extends
+                'application' => $extends,
             );
         }
 

--- a/framework/classes/fuel/config.php
+++ b/framework/classes/fuel/config.php
@@ -81,6 +81,12 @@ class Config extends \Fuel\Core\Config
         return $item;
     }
 
+    public static function extendable_load($module_name, $file_name)
+    {
+        logger(\Fuel::L_WARNING, '\Config::extendable_load is deprecated. Please rename to \Config::loadConfiguration.');
+        return static::loadConfiguration($module_name, $file_name);
+    }
+
     public static function metadata($application_name)
     {
         $metadata = \Config::load($application_name.'::metadata', true);

--- a/framework/classes/fuel/config.php
+++ b/framework/classes/fuel/config.php
@@ -57,8 +57,10 @@ class Config extends \Fuel\Core\Config
         $dependencies = \Nos\Config_Data::get('app_dependencies', array());
 
         if (!empty($dependencies[$app_name])) {
-            foreach ($dependencies[$app_name] as $dependency) {
-                $config = \Arr::merge($config, \Config::load($dependency.'::'.$file_name, true));
+            foreach ($dependencies[$app_name] as $application => $dependency) {
+                if ($dependency['extend_configuration']) {
+                    $config = \Arr::merge($config, \Config::load($application.'::'.$file_name, true));
+                }
             }
         }
         $config = \Arr::recursive_filter(
@@ -77,27 +79,6 @@ class Config extends \Fuel\Core\Config
         $item = str_replace('/', '.', $item);
 
         return $item;
-    }
-
-    public static function extendable_load($module_name, $file_name)
-    {
-        $config = \Config::load($module_name.'::'.$file_name, true);
-        $dependencies = \Nos\Config_Data::get('app_dependencies', array());
-
-        if (!empty($dependencies[$module_name])) {
-            foreach ($dependencies[$module_name] as $dependency) {
-                \Config::load($dependency.'::'.$file_name, true);
-                $config = \Arr::merge($config, \Config::get($dependency.'::'.$file_name, array()));
-            }
-        }
-        $config = \Arr::recursive_filter(
-            $config,
-            function($var) {
-                return $var !== null;
-            }
-        );
-
-        return $config;
     }
 
     public static function metadata($application_name)
@@ -124,7 +105,7 @@ class Config extends \Fuel\Core\Config
 
     public static function application($application_name)
     {
-        return static::extendable_load($application_name, 'config');
+        return static::loadConfiguration($application_name, 'config');
     }
 
     public static function actions($params = array())

--- a/framework/classes/fuel/module.php
+++ b/framework/classes/fuel/module.php
@@ -40,8 +40,8 @@ class Module extends Fuel\Core\Module
             // Load dependent applications
             $dependencies = \Nos\Config_Data::get('app_dependencies', array());
             if (!empty($dependencies[$module])) {
-                foreach ($dependencies[$module] as $dependence) {
-                    static::load($dependence);
+                foreach ($dependencies[$module] as $application => $dependence) {
+                    static::load($application);
                 }
             }
         }

--- a/framework/classes/fuel/orm/model.php
+++ b/framework/classes/fuel/orm/model.php
@@ -313,21 +313,7 @@ class Model extends \Orm\Model
                 $application = array_search($namespace, $namespaces);
             }
 
-            $config = \Config::load($application.'::'.$file_name, true);
-            $dependencies = \Nos\Config_Data::get('app_dependencies', array());
-
-            if (!empty($dependencies[$application])) {
-                foreach ($dependencies[$application] as $dependency) {
-                    \Config::load($dependency.'::'.$file_name, true);
-                    $config = \Arr::merge($config, \Config::get($dependency.'::'.$file_name));
-                }
-            }
-            static::$_configs[$class] = \Arr::recursive_filter(
-                $config,
-                function ($var) {
-                    return $var !== null;
-                }
-            );
+            static::$_configs[$class] = \Config::loadConfiguration($application, $file_name);
         }
 
         return static::$_configs[$class];

--- a/framework/migrations/003_new_dependencies_configuration.php
+++ b/framework/migrations/003_new_dependencies_configuration.php
@@ -1,0 +1,27 @@
+<?php
+namespace Nos\Migrations;
+
+class New_Dependencies_Configuration extends \Nos\Migration
+{
+    public function up()
+    {
+        $config = \Nos\Config_Data::load('app_dependencies');
+        $has_changed = false;
+        foreach ($config as &$dependencies) {
+            $keys = array_keys($dependencies);
+            foreach ($keys as $key) {
+                if (!is_string($key)) {
+                    $has_changed = true;
+                    $extending_application = $dependencies[$key];
+                    unset($dependencies[$key]);
+                    $dependencies[$extending_application] = array(
+                        'extend_configuration' => true
+                    );
+                }
+            }
+        }
+        if ($has_changed) {
+            \Nos\Config_Data::save('app_dependencies', $config);
+        }
+    }
+}

--- a/framework/migrations/003_new_dependencies_configuration.php
+++ b/framework/migrations/003_new_dependencies_configuration.php
@@ -15,7 +15,7 @@ class New_Dependencies_Configuration extends \Nos\Migration
                     $extending_application = $dependencies[$key];
                     unset($dependencies[$key]);
                     $dependencies[$extending_application] = array(
-                        'extend_configuration' => true
+                        'extend_configuration' => true,
                     );
                 }
             }

--- a/framework/migrations/003_new_dependencies_configuration.php
+++ b/framework/migrations/003_new_dependencies_configuration.php
@@ -20,6 +20,7 @@ class New_Dependencies_Configuration extends \Nos\Migration
                 }
             }
         }
+        unset($dependencies);
         if ($has_changed) {
             \Nos\Config_Data::save('app_dependencies', $config);
         }


### PR DESCRIPTION
Note: please merge feature/new_requires_key before since this PR suppose that this has been done before (they are dependent)

This small feature doesn't change anything on standard case, but allows an application to extend an other without merging configuration files (in this case only the bootstrap is loaded). Often the recursive merge aren't enough and handy : therefore it can be useful to disable this behaviour.

instead of writing :

``` php
'extends' => 'app'
```

We can write

``` php
'extends' => array(
    'application' => 'app',
    'extend_configuration' => false // default to true
)
```
