### PR TITLE
Missing preview_url in appdesk and crud

### DIFF
--- a/framework/classes/orm/behaviour/urlenhancer.php
+++ b/framework/classes/orm/behaviour/urlenhancer.php
@@ -19,6 +19,12 @@ class Orm_Behaviour_Urlenhancer extends Orm_Behaviour
      */
     protected $_properties = array();
 
+    public static function dataset(&$dataset)
+    {
+        if (!isset($dataset['preview_url'])) {
+            $dataset['preview_url'] = array(__CLASS__, 'preview_url');
+        }
+    }
     /**
      * Returns an array of all available URL for this item. The array contains:
      *


### PR DESCRIPTION
The behaviour 'urlenhancer' added automatically the 'preview' button (in appdesk and crud), but the preview_url was not set.
