### PR TITLE
prevent from caching tab content

### DIFF
--- a/static/admin/novius-os/js/jquery.novius-os.ostabs.js
+++ b/static/admin/novius-os/js/jquery.novius-os.ostabs.js
@@ -1141,6 +1141,7 @@ define('jquery-nos-ostabs',
                 if (!iframe) {
                     self.xhr = $.ajax({
                         url: url,
+                        cache: false,
                         success: function( r, s, xhr ) {
                             var json;
 


### PR DESCRIPTION
usefull when automatically refreshing a form after saving it.
