### PR TITLE
I propose "is_preview" is true only when you are logged in 

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -85,7 +85,7 @@ class Controller_Front extends Controller
             $url = \Str::sub($url, 0, - strlen($this->_extension) - 1);
         }
 
-        $this->_is_preview = \Input::get('_preview', false);
+        $this->_is_preview = (\Session::get('logged_user_id', false) && \Input::get('_preview', false));
 
         $cache_path = (empty($this->_url) ? 'index/' : $this->_url);
 

--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -85,7 +85,7 @@ class Controller_Front extends Controller
             $url = \Str::sub($url, 0, - strlen($this->_extension) - 1);
         }
 
-        $this->_is_preview = (\Session::get('logged_user_id', false) && \Input::get('_preview', false));
+        $this->_is_preview = (Auth::check() && \Input::get('_preview', false));
 
         $cache_path = (empty($this->_url) ? 'index/' : $this->_url);
 


### PR DESCRIPTION
is_preview is true when you access ?_preview=1 .
That means, users who are not logged in, can view non published page. This might cause a leakage of information.
