### PR TITLE
Bugfix: take modifications of cache_path in event front.start into account

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -102,7 +102,7 @@ class Controller_Front extends Controller
 
         \Event::trigger_function('front.start', array(array('url' => &$url, 'cache_path' => &$cache_path)));
 
-        $cache_path = \Nos\FrontCache::getPathFromUrl($this->_base_href, $this->_url);
+        $cache_path = \Nos\FrontCache::getPathFromUrl($this->_base_href, $cache_path);
 
         $this->_cache = FrontCache::forge($cache_path);
 


### PR DESCRIPTION
Fix a regression introduced in be9211f001b5713bb6512bfab6b05ab242103dc6

The modification of $cache_path in the event front.start was no longer used.
It was working in chiba.1, and no longer working in chiba.2.
