### PR TITLE
use "value" key to populate renderer_date when building it standalone

### DIFF
--- a/framework/classes/renderer/datetime/picker.php
+++ b/framework/classes/renderer/datetime/picker.php
@@ -68,7 +68,8 @@ class Renderer_Datetime_Picker extends Renderer
         $fieldset = \Fieldset::build_from_config(array(
             $renderer['name'] => $renderer,
         ));
-        return $fieldset->field($renderer['name'])->set_template('{field}')->build().$fieldset->build_append();
+        $fieldset->field($renderer['name'])->set_value(!empty($renderer['value']) ? $renderer['value'] : '' );
+        return $field->set_template('{field}')->build().$fieldset->build_append();
     }
 
     /**

--- a/framework/classes/renderer/datetime/picker.php
+++ b/framework/classes/renderer/datetime/picker.php
@@ -68,7 +68,7 @@ class Renderer_Datetime_Picker extends Renderer
         $fieldset = \Fieldset::build_from_config(array(
             $renderer['name'] => $renderer,
         ));
-        $fieldset->field($renderer['name'])->set_value(!empty($renderer['value']) ? $renderer['value'] : '' );
+        $field = $fieldset->field($renderer['name'])->set_value(!empty($renderer['value']) ? $renderer['value'] : '' );
         return $field->set_template('{field}')->build().$fieldset->build_append();
     }
 


### PR DESCRIPTION
It seems that building a renderer standalione (static method) does not take account of the "value" key to populate the renderer.

\Nos\Renderer_Time_Picker::renderer(array(
        'name' => 'name',
        'value' => $date,
));
