### PR TITLE
Considers cache dirty if cache duration changes

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -105,6 +105,7 @@ class Controller_Front extends Controller
         $cache_path = \Nos\FrontCache::getPathFromUrl($this->_base_href, $cache_path);
 
         $this->_cache = FrontCache::forge($cache_path);
+        \Nos\FrontCache::$cache_duration = $this->_cache_duration;
 
         try {
             if (!$this->_use_cache) {

--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -22,6 +22,8 @@ class FrontCache
 {
     protected static $_php_begin = null;
 
+    public static $cache_duration = 60;
+
     /**
      * Loads any default caching settings when available
      */
@@ -215,9 +217,12 @@ class FrontCache
         $this->_level = ob_get_level();
     }
 
-    public static function checkExpires($expires)
+    public static function checkExpires($expires, $initial_cache_duration)
     {
         if ($expires > 0 && $expires <= time()) {
+            throw new CacheExpiredException();
+        }
+        if ($initial_cache_duration > static::$cache_duration) {
             throw new CacheExpiredException();
         }
     }
@@ -234,7 +239,7 @@ class FrontCache
             $expires = time() + $duration;
             $prepend .= '<?php
 
-            '.__CLASS__.'::checkExpires('.$expires.');'."\n";
+            '.__CLASS__.'::checkExpires('.$expires.', '.$duration.');'."\n";
 
             if (!empty($controller)) {
                 if ($this->_path === $this->_init_path && !empty($this->_suffix_handlers)) {

--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -217,7 +217,7 @@ class FrontCache
         $this->_level = ob_get_level();
     }
 
-    public static function checkExpires($expires, $initial_cache_duration)
+    public static function checkExpires($expires, $initial_cache_duration = 0)
     {
         if ($expires > 0 && $expires <= time()) {
             throw new CacheExpiredException();


### PR DESCRIPTION
If current cache_duration is shorter than initial cache_duration (when cache was written), considers the cache dirty and throw a CacheExpiredException.

Certainly more useful in development mode where cache duration can depend on cookies or devices than in production mode.
