### PR TITLE
Bugfix: \Nos\FrontCache::get() doesn't work if duration>60

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -96,12 +96,20 @@ class FrontCache
         );
 
         $cache = new static($path);
+
+        $old_cache_duration = static::$cache_duration;
+        static::$cache_duration = $params['duration'];
+
         try {
-            return $cache->executeOrStart($params['controller']);
+            $result = $cache->executeOrStart($params['controller']);
+            static::$cache_duration = $old_cache_duration;
+            return $result;
         } catch (CacheNotFoundException $e) {
             call_user_func_array($params['callback_func'], $params['callback_args']);
 
-            return $cache->saveAndExecute($params['duration'], $params['controller']);
+            $result = $cache->saveAndExecute($params['duration'], $params['controller']);
+            static::$cache_duration = $old_cache_duration;
+            return $result;
         }
     }
 


### PR DESCRIPTION
Bug introduced in 4b0dd69793775b74dcd248e2c6f19df3e1cd80d1
