### PR TITLE
Could not use Model_User::checkPermission() due to a typo

### DIFF
--- a/framework/applications/noviusos_user/classes/model/user.model.php
+++ b/framework/applications/noviusos_user/classes/model/user.model.php
@@ -204,7 +204,7 @@ class Model_User extends \Nos\Orm\Model
      */
     public function checkPermission($permission_name, $category_key = null, $allowEmpty = false)
     {
-        return $this->checkRolesPermissions('exists', func_get_args());
+        return $this->checkRolesPermission('exists', $permission_name, $category_key, $allowEmpty);
     }
 
     /**


### PR DESCRIPTION
There was a typo in the function name and the way it was called as well. Usually permissions are checked through `\Nos\User\Permission`.
However this class works only if the user is logged in the admin.

Any application using Model_User as front-end user model would not be able to use `\Nos\User\Permission` and would have to rely on this buggy method call.
