### PR TITLE
make 'query' key optional on inspetor Model

### DIFF
--- a/framework/classes/controller/inspector/model.ctrl.php
+++ b/framework/classes/controller/inspector/model.ctrl.php
@@ -83,7 +83,7 @@ class Controller_Inspector_Model extends Controller_Inspector
             $data_mapping = isset($common_config['data_mapping']) ? $common_config['data_mapping'] : array(); //@todo: allow customization
 
             if (!isset($config['query'])) {
-                $config['query'] = $common_config['query'];
+                $config['query'] = empty($common_config['query']) ? array() : $common_config['query'];
             }
 
             if (!isset($config['query']['model'])) {


### PR DESCRIPTION
I'm not sure if this is the right way to fix this.
However, 'query' key seems to be optional as the only time it's used it is merged with a default config (line 45 of the same file).
Moreover, everything else seems to work when using an empty array (listing models and filtering the appdesk).
