### PR TITLE
rm \Command::_clear_args

### DIFF
--- a/framework/classes/fuel/oil/command.php
+++ b/framework/classes/fuel/oil/command.php
@@ -165,17 +165,6 @@ class Command extends \Oil\Command
         }
 
     }
-
-    private static function _clear_args($actions = array())
-    {
-        foreach ($actions as $key => $action) {
-            if (mb_substr($action, 0, 1) === '-') {
-                unset($actions[$key]);
-            }
-        }
-
-        return $actions;
-    }
 }
 
 /* End of file oil/classes/command.php */


### PR DESCRIPTION
This method is now protected on \Oil\Command class.

> Compile Error - Access level to Command::_clear_args() must be protected (as in class Oil\Command) or weaker in .../novius-os/framework/classes/fuel/oil/command.php
