### PR TITLE
Bugfix Oil\Refine::run()

### DIFF
--- a/framework/classes/fuel/oil/refine.php
+++ b/framework/classes/fuel/oil/refine.php
@@ -11,7 +11,7 @@
 class Refine extends Oil\Refine
 {
 
-    public static function run($task, $args)
+    public static function run($task, $args = array())
     {
         $task = strtolower($task);
 


### PR DESCRIPTION
> Error: Declaration of Refine::run() should be compatible with Oil\Refine::run($task, $args = Array) in .../framework/classes/fuel/oil/refine.php on 12
