### PR TITLE
bugfix on twinnable many many suppression

### DIFF
--- a/framework/classes/orm/twinnable/manymany.php
+++ b/framework/classes/orm/twinnable/manymany.php
@@ -310,16 +310,15 @@ class Orm_Twinnable_ManyMany extends \Orm\ManyMany
     public function delete_related($model_from)
     {
         //search for twin models
-        $query = \DB::select()->from($this->table_through);
+        $query = \DB::select()->from($model_from::table());
         reset($this->key_from);
-        foreach ($this->key_through_from as $key) {
+        foreach ($this->key_from as $key) {
             $query->where($key, '=', $model_from->{current($this->key_from)});
             next($this->key_from);
         }
         $result = $query->execute(call_user_func(array($model_from, 'connection')));
-        //if there's more than one result, prevent from deleting relation (still used by twin models)
-        //otherwise, the current model is the last to use te relation and relation can be destroyed
-        if (count($result) === 1) {
+        //if there's one result or more, prevent from deleting relation (still used by twin models)
+        if (count($result) === 0) {
             parent::delete_related($model_from);
         }
     }


### PR DESCRIPTION
Made two errors when wrting the previous corresponding PR #70 : 
- must check on the orginal table if there's still models with the same common_id (instead of the related table)
- the current item seems to be already deleted by the time the delete_related method is called : 0 model should be found with the same common id.
