### PR TITLE
Add a new behaviour to implement a fake relation with data on it

### DIFF
--- a/framework/classes/model/datamany.model.php
+++ b/framework/classes/model/datamany.model.php
@@ -29,6 +29,39 @@ abstract class Model_DataMany extends \Nos\Orm\Model
     protected static $_belongs_to = array(
     );
 
+    //related models (optionals)
+    protected static $_model_to = '';
+    protected static $_model_from = '';
+
+
+    public static function _init() {
+        //First set the name of the has_one relation if needed
+        if (empty(static::$_rel_to_name)) {
+            static::$_rel_to_name = reset(array_keys(static::$_has_one));//get the first "has_one" relation and assume it's the right one
+        }
+        //The set the related model
+        if (empty(static::$_model_to)) {
+            $relation_to = static::$_has_one[static::$_rel_to_name];
+            if (empty($relation_to)) {
+                throw new \FuelException('A related model is needed in a has_one relation for '.get_called_class());
+            }
+            static::$_model_to = $relation_to['model_to'];
+        }
+
+        //Then do the same for the belongs_to model and relation name
+        if (empty(static::$_rel_from_name)) {
+            static::$_rel_from_name = reset(array_keys(static::$_belongs_to));//get the first "belongs_to" relation and assume it's the right one
+        }
+        if (empty(static::$_model_from)) {
+            $relation_from = static::$_belongs_to[static::$_rel_from_name];
+            if (empty($relation_from)) {
+                throw new \FuelException('A related model is needed in a belongs_to relation for '.get_called_class());
+            }
+            static::$_model_from = $relation_from['model_to'];
+        }
+    }
+
+
     /**
      * get on the model or on the related model
      * => when trying to have access to a related model, there's no need to use two linked relation, just one is needed
@@ -37,25 +70,8 @@ abstract class Model_DataMany extends \Nos\Orm\Model
      */
     public function & __get($name)
     {
-        if (empty(static::$_rel_to_name)) {
-            static::$_rel_to_name = reset(array_keys(static::$_has_one));//get the first "has_one" relation and assume it's the right one
-        }
-        $relation_to = static::$_has_one[static::$_rel_to_name];
-        if (empty($relation_to)) {
-            throw new \FuelException('A related model is needed in a has_one relation for '.get_called_class());
-        }
-        $model_to = $relation_to['model_to'];
-
-        if (empty(static::$_rel_from_name)) {
-            static::$_rel_from_name = reset(array_keys(static::$_belongs_to));//get the first "belongs_to" relation and assume it's the right one
-        }
-        $relation_from = static::$_belongs_to[static::$_rel_from_name];
-        if (empty($relation_from)) {
-            throw new \FuelException('A related model is needed in a belongs_to relation for '.get_called_class());
-        }
-        $model_from = $relation_from['model_to'];
-
-
+        $model_to = static::$_model_to;
+        $model_from = static::$_model_from;
         if ((array_key_exists($name, $model_to::properties())
                 || array_key_exists($name, $model_to::relations()))
             && !empty($this->{static::$_rel_to_name})) {

--- a/framework/classes/model/datamany.model.php
+++ b/framework/classes/model/datamany.model.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2011 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link http://www.novius-os.org
+ */
+
+namespace Nos;
+
+abstract class Model_DataMany extends \Nos\Orm\Model
+{
+    protected static $_table_name = '';
+    protected static $_primary_key = array();//two keys refering to two models
+    protected static $_properties = array(
+        //the two keys above and data added to the simulated relation
+    );
+
+    protected static $_has_one = array(
+        //has one works the same way as a belongs to, it will be used to determine properties
+    );
+
+    protected static $_belongs_to = array(
+    );
+
+    /**
+     * get on the model or on the related model
+     * => when trying to have access to a related model, there's no need to use two linked relation, just one is needed
+     * @param $name string : a property
+     * @return mixed|Orm\Model|null : the value of the corresponding property
+     */
+    public function & __get($name)
+    {
+        $relation_to = reset(static::$_has_one);
+        $relation_to_name = reset(array_keys(static::$_has_one));
+        if (empty($relation_to)) {
+            throw new \FuelException('A related model is needed in a has_one relation for '.get_called_class());
+        }
+        $model_to = $relation_to['model_to'];
+
+        $relation_from = reset(static::$_belongs_to);
+        $relation_from_name = reset(array_keys(static::$_belongs_to));
+        if (empty($relation_from)) {
+            throw new \FuelException('A related model is needed in a belongs_to relation for '.get_called_class());
+        }
+        $model_from = $relation_from['model_to'];
+
+
+        if ((array_key_exists($name, $model_to::properties())
+                || array_key_exists($name, $model_to::relations()))
+            && !empty($this->{$relation_to_name})) {
+            return $this->{$relation_to_name}->get($name);
+        } elseif ((array_key_exists($name, $model_from::properties())
+                || array_key_exists($name, $model_from::relations()))
+            && !empty($this->{$relation_from_name})) {
+            return $this->{$relation_from_name}->get($name);
+        }
+        return parent::__get($name);
+    }
+}

--- a/framework/classes/model/datamany.model.php
+++ b/framework/classes/model/datamany.model.php
@@ -70,17 +70,22 @@ abstract class Model_DataMany extends \Nos\Orm\Model
      */
     public function & __get($name)
     {
-        $model_to = static::$_model_to;
-        $model_from = static::$_model_from;
-        if ((array_key_exists($name, $model_to::properties())
-                || array_key_exists($name, $model_to::relations()))
-            && !empty($this->{static::$_rel_to_name})) {
-            return $this->{static::$_rel_to_name}->get($name);
-        } elseif ((array_key_exists($name, $model_from::properties())
-                || array_key_exists($name, $model_from::relations()))
-            && !empty($this->{static::$_rel_from_name})) {
-            return $this->{static::$_rel_from_name}->get($name);
+        try {
+            return parent::__get($name);
+        } catch (\OutOfBoundsException $e) {
+            //if the Model_DataMany does not have such a property, try to retrieve it from the related model
+            $model_to = static::$_model_to;
+            $model_from = static::$_model_from;
+            if ((array_key_exists($name, $model_to::properties())
+                    || array_key_exists($name, $model_to::relations()))
+                && !empty($this->{static::$_rel_to_name})) {
+                return $this->{static::$_rel_to_name}->get($name);
+            } elseif ((array_key_exists($name, $model_from::properties())
+                    || array_key_exists($name, $model_from::relations()))
+                && !empty($this->{static::$_rel_from_name})) {
+                return $this->{static::$_rel_from_name}->get($name);
+            }
+            throw new \OutOfBoundsException('Property "'.$name.'" not found for '.get_class($this).' or its related model.');
         }
-        return parent::__get($name);
     }
 }

--- a/framework/classes/model/datamany.model.php
+++ b/framework/classes/model/datamany.model.php
@@ -20,18 +20,15 @@ abstract class Model_DataMany extends \Nos\Orm\Model
     
     //relation names used to create the link with data between two models
     protected static $_rel_to_name = '';
-    protected static $_rel_from_name = '';
 
     protected static $_has_one = array(
-        //has one works the same way as a belongs to, it will be used to determine properties
     );
 
     protected static $_belongs_to = array(
     );
 
-    //related models (optionals)
+    //related model (optional)
     protected static $_model_to = '';
-    protected static $_model_from = '';
 
 
     public static function _init() {
@@ -39,25 +36,13 @@ abstract class Model_DataMany extends \Nos\Orm\Model
         if (empty(static::$_rel_to_name)) {
             static::$_rel_to_name = reset(array_keys(static::$_has_one));//get the first "has_one" relation and assume it's the right one
         }
-        //The set the related model
+        //Then set the related model
         if (empty(static::$_model_to)) {
             $relation_to = static::$_has_one[static::$_rel_to_name];
             if (empty($relation_to)) {
                 throw new \FuelException('A related model is needed in a has_one relation for '.get_called_class());
             }
             static::$_model_to = $relation_to['model_to'];
-        }
-
-        //Then do the same for the belongs_to model and relation name
-        if (empty(static::$_rel_from_name)) {
-            static::$_rel_from_name = reset(array_keys(static::$_belongs_to));//get the first "belongs_to" relation and assume it's the right one
-        }
-        if (empty(static::$_model_from)) {
-            $relation_from = static::$_belongs_to[static::$_rel_from_name];
-            if (empty($relation_from)) {
-                throw new \FuelException('A related model is needed in a belongs_to relation for '.get_called_class());
-            }
-            static::$_model_from = $relation_from['model_to'];
         }
     }
 
@@ -75,15 +60,10 @@ abstract class Model_DataMany extends \Nos\Orm\Model
         } catch (\OutOfBoundsException $e) {
             //if the Model_DataMany does not have such a property, try to retrieve it from the related model
             $model_to = static::$_model_to;
-            $model_from = static::$_model_from;
             if ((array_key_exists($name, $model_to::properties())
                     || array_key_exists($name, $model_to::relations()))
                 && !empty($this->{static::$_rel_to_name})) {
                 return $this->{static::$_rel_to_name}->get($name);
-            } elseif ((array_key_exists($name, $model_from::properties())
-                    || array_key_exists($name, $model_from::relations()))
-                && !empty($this->{static::$_rel_from_name})) {
-                return $this->{static::$_rel_from_name}->get($name);
             }
             throw new \OutOfBoundsException('Property "'.$name.'" not found for '.get_class($this).' or its related model.');
         }

--- a/framework/classes/orm/behaviour/datamany.php
+++ b/framework/classes/orm/behaviour/datamany.php
@@ -24,8 +24,10 @@ class Orm_Behaviour_DataMany extends Orm_Behaviour
         $relation = $this->_properties['relation'];
         $diff = $item->get_diff();
         if (!empty($diff[0]) && !empty($diff[0][$relation])) {
+            $class = get_class($item);
+            $pk = implode('.', (array) $item->primary_key());//primary key is an array
             $new_keys = array_keys($item->{$relation});
-            static::$_former_ids = array_diff($diff[0][$relation], $new_keys);
+            static::$_former_ids[$class.'::'.$pk] = array_diff($diff[0][$relation], $new_keys);
         }
     }
 
@@ -34,7 +36,9 @@ class Orm_Behaviour_DataMany extends Orm_Behaviour
     }
 
     public function to_delete(Model $item) {
-        $former_keys = static::$_former_ids;
+        $class = get_class($item);
+        $pk = implode('.', (array) $item->primary_key());//primary key is an array
+        $former_keys = static::$_former_ids[$class.'::'.$pk];
         $delete = !empty($former_keys);
         if ($delete) {
             $relation_name = $this->_properties['relation'];
@@ -56,8 +60,10 @@ class Orm_Behaviour_DataMany extends Orm_Behaviour
     }
 
     public function before_delete(Model $item) {
+        $class = get_class($item);
+        $pk = implode('.', (array) $item->primary_key());//primary key is an array
         $relation = $this->_properties['relation'];
-        static::$_former_ids = array_keys($item->{$relation});
+        static::$_former_ids[$class.'::'.$pk] = array_keys($item->{$relation});
         $item->{$relation} = array();
     }
 

--- a/framework/classes/orm/behaviour/datamany.php
+++ b/framework/classes/orm/behaviour/datamany.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2011 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link http://www.novius-os.org
+ */
+
+namespace Nos;
+
+use Nos\Orm\Model;
+
+class Orm_Behaviour_DataMany extends Orm_Behaviour
+{
+    protected static $_former_ids = array();
+
+    /**
+     * methods below check if some keys won't be used anymore in order to delete them afterward
+     */
+
+    public function before_save(Model $item) {
+        $relation = $this->_properties['relation'];
+        $diff = $item->get_diff();
+        if (!empty($diff[0]) && !empty($diff[0][$relation])) {
+            $new_keys = array_keys($item->{$relation});
+            static::$_former_ids = array_diff($diff[0][$relation], $new_keys);
+        }
+    }
+
+    public function after_save(Model $item) {
+        $this->to_delete($item);
+    }
+
+    public function to_delete(Model $item) {
+        $former_keys = static::$_former_ids;
+        $delete = !empty($former_keys);
+        if ($delete) {
+            $relation_name = $this->_properties['relation'];
+            $relation = $item->relations($relation_name);
+            $model = $relation->model_to;
+            $query = \DB::delete($model::table());
+            foreach ($former_keys as $key) {
+                $ids = explode('][', substr($key, 1, -1));
+                $query->or_where_open();
+                reset($ids);
+                foreach($model::primary_key() as $pkey) {
+                    $query->where($pkey, current($ids));
+                    next($ids);
+                }
+                $query->or_where_close();
+            }
+            $query->execute();
+        }
+    }
+
+    public function before_delete(Model $item) {
+        $relation = $this->_properties['relation'];
+        static::$_former_ids = array_keys($item->{$relation});
+        $item->{$relation} = array();
+    }
+
+    public function after_delete(Model $item) {
+        $this->to_delete($item);
+    }
+}

--- a/framework/classes/orm/behaviour/datamany.php
+++ b/framework/classes/orm/behaviour/datamany.php
@@ -16,6 +16,13 @@ class Orm_Behaviour_DataMany extends Orm_Behaviour
 {
     protected static $_former_ids = array();
 
+    public function __construct($class) {
+        parent::__construct($class);
+        if (empty($this->_properties['relation'])) {
+            throw new \Exception('A relation name must be provided to use Behaviour DataMany on class '.$class);
+        }
+    }
+
     /**
      * methods below check if some keys won't be used anymore in order to delete them afterward
      */

--- a/framework/classes/orm/behaviour/datamany.php
+++ b/framework/classes/orm/behaviour/datamany.php
@@ -32,10 +32,10 @@ class Orm_Behaviour_DataMany extends Orm_Behaviour
     }
 
     public function after_save(Model $item) {
-        $this->to_delete($item);
+        $this->toDelete($item);
     }
 
-    public function to_delete(Model $item) {
+    protected function toDelete(Model $item) {
         $class = get_class($item);
         $pk = implode('.', (array) $item->primary_key());//primary key is an array
         $former_keys = static::$_former_ids[$class.'::'.$pk];
@@ -68,6 +68,6 @@ class Orm_Behaviour_DataMany extends Orm_Behaviour
     }
 
     public function after_delete(Model $item) {
-        $this->to_delete($item);
+        $this->toDelete($item);
     }
 }


### PR DESCRIPTION
an abstract model is provided to construct the fake relation

A way to use it should be like this (for an orderered relation) :

Class :

``` php
<?php
namespace Catalogue;

class Model_OrderMany extends \Nos\Model_DataMany
{
    protected static $_table_name = 'product_gamme';
    protected static $_primary_key = array('gamm__id', 'prod__id');
    protected static $_properties = array(
        'gamm__id',
        'prod__id',
        'prod_order',
    );

    protected static $_has_one = array(
        'product' => array(
            'key_from' => 'prod__id',
            'model_to' => 'Catalogue\Model_Product',
            'key_to' => 'prod_id',
            'cascade_save' => false,
            'cascade_delete' => false,
        )
    );

    protected static $_belongs_to = array(
        'gamme' => array(
            'key_from' => 'gamm__id',
            'model_to' => 'Catalogue\Model_Gamme',
            'key_to' => 'gamm_id',
            'cascade_save' => false,
            'cascade_delete' => false,
        ),
    );
}
```

Model with the behaviour : 

``` php
 protected static $_has_many = array(
        'products' => array(
            'key_from' => 'gamm_id',
            'model_to' => 'Catalogue\Model_OrderMany',
            'key_to' => 'gamm__id',
            'cascade_save' => true,
            'cascade_delete' => false,
            'conditions' => array(
                'order_by' => array('prod_order')
            )
        ),
    );

protected static $_behaviours = array(
        'Nos\Orm_Behaviour_DataMany' => array(
            'events' => array('before_save', 'after_save', 'after_delete', 'before_delete'),
            'relation' => 'products',
        ),
    );
```
