### PR TITLE
Fix for plural i18n

### DIFF
--- a/framework/classes/i18n.php
+++ b/framework/classes/i18n.php
@@ -372,7 +372,7 @@ class I18n
                 }
             }
             if (empty($result)) {
-                $result = $default ?: $message;
+                $result = $default === null ? $message : $default;
             }
             return $result;
         };


### PR DESCRIPTION
The plural translation function n__() always returned the singular form
