### PR TITLE
Make a specific cache for 404 errors

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -88,10 +88,9 @@ class Controller_Front extends Controller
         // Why Session::get() instead of Auth::check()? See https://github.com/novius-os/core/pull/52#issuecomment-21237309
         $this->_is_preview = \Input::get('_preview', false) && \Session::get('logged_user_id', false);
 
+        $cache_path = (empty($this->_url) ? 'index/' : $this->_url);
         if ($status == 404) {
-            $cache_path = '404.error/';
-        } else {
-            $cache_path = (empty($this->_url) ? 'index/' : $this->_url);
+            $cache_path = '404.error/'.$cache_path;
         }
 
         // POST or preview means no cache. Ever.

--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -88,7 +88,11 @@ class Controller_Front extends Controller
         // Why Session::get() instead of Auth::check()? See https://github.com/novius-os/core/pull/52#issuecomment-21237309
         $this->_is_preview = \Input::get('_preview', false) && \Session::get('logged_user_id', false);
 
-        $cache_path = (empty($this->_url) ? 'index/' : $this->_url);
+        if ($status == 404) {
+            $cache_path = '404.error/';
+        } else {
+            $cache_path = (empty($this->_url) ? 'index/' : $this->_url);
+        }
 
         // POST or preview means no cache. Ever.
         // We don't want cache in DEV except if _cache=1


### PR DESCRIPTION
This prevent the home page to send a 404 status instead of a 200.

Create a "404.error.php" file into the cache directory to store the result of a "page not found" result.

This PR can also be merged in Novius OS Dubrovka.
