### PR TITLE
Filter argument for the preview view set to false

### DIFF
--- a/framework/classes/controller/admin/enhancer.ctrl.php
+++ b/framework/classes/controller/admin/enhancer.ctrl.php
@@ -132,7 +132,7 @@ class Controller_Admin_Enhancer extends \Nos\Controller_Admin_Application
                 'layout' => $this->config['preview']['layout'],
                 'params' => $this->config['preview']['params'],
                 'enhancer_args' => $args,
-            ))->render(),
+            ), false)->render(),
         );
         \Response::json($body);
     }


### PR DESCRIPTION
This prevent errors when rendering special char into html. With the filter argument to true, special char are encoded and so the json can't read it and no preview is displayed.

Can also be merged in Novius OS Dubrovka
