### PR TITLE
Bugfix for virtualpath

### DIFF
--- a/framework/classes/orm/behaviour/virtualpath.php
+++ b/framework/classes/orm/behaviour/virtualpath.php
@@ -170,10 +170,15 @@ class Orm_Behaviour_Virtualpath extends Orm_Behaviour_Virtualname
                 }
             }
 
-            \DB::update($item->table())
+            $update = \DB::update($item->table())
                 ->set($replaces)
-                ->where($virtual_path_property, 'LIKE', $old_virtual_path.'%')
-                ->execute();
+                ->where($virtual_path_property, 'LIKE', $old_virtual_path.'%');
+                
+            if (is_array($this->_properties['unique_path']) && !empty($this->_properties['unique_path']['context_property'])) {
+                $update->where($this->_properties['unique_path']['context_property'], '=', $item->{$this->_properties['unique_path']['context_property']});
+            }
+            
+            $update->execute();
 
             $item->observe('after_change_virtual_path');
         }


### PR DESCRIPTION
The virtual path was changed for all items without take in count the context. So you could change a url for a subpage "C" of a context by changing the virtualname of a parent page "A" of an other context (if the parent page "B" of the first context has the same virtual name than "A").

A simple example with 3 pages :
- A is in context main.
- B and C are in context second.
- A and B have the same virtual name "ok.html".
- C is the child of B (so it virtual path is "ok/C.html").
- You change A virtual name to "test.html".
- C virtual name become "test/C.html" instead of staying "ok/C.html".

This commit fix this.
