### PR TITLE
Add path to distinguish medias with same name in different folders

### DIFF
--- a/framework/applications/noviusos_media/config/common/media.config.php
+++ b/framework/applications/noviusos_media/config/common/media.config.php
@@ -83,6 +83,10 @@ return array(
                 return dirname($item->url(false));
             },
         ),
+        'media_path' => array(
+            'title' => __('Path'),
+            'column' => 'media_path',
+        ),
         'image' => array(
             'value' => function ($item) {
                 return $item->isImage();

--- a/framework/applications/noviusos_media/config/controller/admin/appdesk.config.php
+++ b/framework/applications/noviusos_media/config/controller/admin/appdesk.config.php
@@ -33,7 +33,7 @@ return array(
         ),
         'order_by' => array('media_id' => 'DESC'),
     ),
-    'search_text' => 'media_title',
+    'search_text' => array('media_title', 'media_path'),
     'inspectors' => array(
         'folder',
         'extension',


### PR DESCRIPTION
- media_path can help to distinguish 2 medias with same name in different folders
- search is now possible on media_path
