### PR TITLE
Fix for plural i18n

### DIFF
--- a/framework/classes/i18n.php
+++ b/framework/classes/i18n.php
@@ -339,7 +339,7 @@ class I18n
 
     public static function nTranslateFromFile($file, $singular, $plural, $n)
     {
-        $result = static::translate_from_file($file, $singular);
+        $result = static::translate_from_file($file, $singular, false);
 
         return static::plural($result, $singular, $plural, $n);
     }


### PR DESCRIPTION
The previous fix on plural i18n was not complete, this fix makes the plural work as expected.

The translate_from_file() method return the singular form if no translation were found and if the default value is null, but for the plural() method to work we need to pass a falsy value or an array. To bypass this behaviour we need to set false as default value for translate_from_file().
