### PR TITLE
force browsers to renew their cache when an image is updated

### DIFF
--- a/framework/applications/noviusos_media/config/common/media.config.php
+++ b/framework/applications/noviusos_media/config/common/media.config.php
@@ -72,7 +72,7 @@ return array(
          ),
         'path' => array(
             'value' => function ($item) {
-                return $item->url();
+                return $item->url().($item->isImage() ? '?t='.urlencode($item->media_updated_at) : '');
             },
         ),
         'path_folder' => array(
@@ -87,7 +87,7 @@ return array(
         ),
         'thumbnail' => array(
             'value' => function ($item) {
-                return $item->isImage() ? $item->urlResized(64, 64) : '';
+                return $item->isImage() ? $item->urlResized(64, 64).'?t='.urlencode($item->media_updated_at) : '';
             },
         ),
         'height' => array(

--- a/framework/applications/noviusos_media/views/admin/media_edit.view.php
+++ b/framework/applications/noviusos_media/views/admin/media_edit.view.php
@@ -28,7 +28,7 @@ $main_col_size = 11;
 if ($item->isImage()) {
     $main_col_size -= 3;
     echo '<div class="col c3 preview_zone">';
-    $src = $item->urlResized(512, 512);
+    $src = $item->urlResized(512, 512).'?t='.urlencode($item->media_updated_at);
     echo '<img src="'.$src.'" />';
     echo '</div>';
 }


### PR DESCRIPTION
When the file is changed but the path didn't, browsers can still display the older image even if it has changed.
This patch add the date of the last update to still keep cache as long as it is not modified and to force browsers renewing the cache when it is.

In common.config : 
'path' is used to visualise image in back office
'thumbnail' is used for preview appdesk grid

I don't know which one of the above is used for the renderer_media, but I saw consequences on it too.

Change in media_edit.view is used for crud edit of medias.
