### PR TITLE
Commons configurations now take all the model path's to be defined.

### DIFF
--- a/framework/classes/config/common.php
+++ b/framework/classes/config/common.php
@@ -12,8 +12,12 @@ class Config_Common
 
         //Fallback on old common config configuration
         if (empty($config)) {
+            $good_file = $file; //used for deprecated message only
             $file = 'common'.substr($file, strrpos($file, DS));
             $config = \Config::load($application_name.'::'.$file, true);
+            if (!empty($config) && (\Fuel::$env == \Fuel::DEVELOPMENT)) {
+                \Log::deprecated('For model '.$model.'. Put the common configuration directly into the common folder is deprecated. Please put it into '.$good_file.'.config.php');
+            }
         }
 
         $config = static::process_placeholders($model, $config);

--- a/framework/classes/config/common.php
+++ b/framework/classes/config/common.php
@@ -6,9 +6,15 @@ class Config_Common
     public static function load($model, $filter_data_mapping = array())
     {
         list($application_name, $file) = \Config::configFile($model);
-        $file = 'common'.substr($file, strrpos($file, DS));
+        $file = 'common'.substr($file, strpos($file, DS));
 
         $config = \Config::load($application_name.'::'.$file, true);
+
+        //Fallback on old common config configuration
+        if (empty($config)) {
+            $file = 'common'.substr($file, strrpos($file, DS));
+            $config = \Config::load($application_name.'::'.$file, true);
+        }
 
         $config = static::process_placeholders($model, $config);
         $config = static::process_callable_keys($config);

--- a/framework/classes/config/common.php
+++ b/framework/classes/config/common.php
@@ -16,7 +16,7 @@ class Config_Common
             $file = 'common'.substr($file, strrpos($file, DS));
             $config = \Config::load($application_name.'::'.$file, true);
             if (!empty($config) && (\Fuel::$env == \Fuel::DEVELOPMENT)) {
-                \Log::deprecated('For model '.$model.'. Put the common configuration directly into the common folder is deprecated. Please put it into '.$good_file.'.config.php');
+                \Log::deprecated('For model '.$model.'. Put the common configuration directly into the common folder is deprecated. Please put it into '.$good_file.'.config.php', 'Elche');
             }
         }
 


### PR DESCRIPTION
A fallback for the old system is in place to prevent breaking change.
