### PR TITLE
Remove this useless delete method for Twinnable_ManyMany :

### DIFF
--- a/framework/classes/orm/twinnable/manymany.php
+++ b/framework/classes/orm/twinnable/manymany.php
@@ -457,14 +457,4 @@ class Orm_Twinnable_ManyMany extends \Orm\ManyMany
             parent::delete_related($model_from);
         }
     }
-
-    public function delete($model_from, $models_to, $parent_deleted, $cascade)
-    {
-        // If not cascade, others twins use the relation
-        // see \Nos\Orm\Model->should_cascade_delete()
-        // prevent parent delete() to set the foreign key to null
-        if ((bool) $cascade) {
-            return parent::delete($model_from, $models_to, $parent_deleted, $cascade);
-        }
-    }
 }


### PR DESCRIPTION
This delete method for Twinnable_ManyMany is useless : 
- if $cascade === false, parent::delete() only call $this->delete_related()
- if these's twin models, $this->delete_related() doesn't delete relationship entries
