### PR TITLE
Bugfix : Indentation of menus wasn't displayed correctly in CRUD

### DIFF
--- a/framework/applications/noviusos_menu/static/js/jquery.ui.renderer-menu-items.js
+++ b/framework/applications/noviusos_menu/static/js/jquery.ui.renderer-menu-items.js
@@ -69,7 +69,7 @@ define('jquery-nos-renderer-menu-items',
                     o = self.options,
                     item = $li.data('item') || {},
                     $liDiv = $('<div></div>'),
-                    $liChildren = $li.find('ol').detach(),
+                    $liChildren = $li.find('> ol').detach(),
                     $liForm = $('<div></div>').append($li.contents()),
                     $liLabel;
 


### PR DESCRIPTION
By selecting only the direct ol child of the current li node, the indentation of the menu is correct.

Before that, all level below level 2 was displayed at the same level, because all sub list were selected in the `$liChildren` variable.
