### PR TITLE
allow to custom title_item thanks to config

### DIFF
--- a/framework/classes/fuel/orm/model.php
+++ b/framework/classes/fuel/orm/model.php
@@ -583,11 +583,24 @@ class Model extends \Orm\Model
      */
     public function title_item()
     {
-        $title_property = static::title_property();
-        if (is_callable($title_property)) {
-            return $title_property($this);
-        } elseif (is_string($title_property)) {
-            return $this->{$title_property};
+        $config = static::configModel();
+        if (!empty($config) && !empty($config['title_item'])) {
+            $title = $config['title_item'];
+            if (is_callable($title)) {
+                return $title($this);
+            } elseif (is_string($title)) {
+                return $title;
+            }
+        } else {
+            $title_property = static::title_property();
+            if (is_callable($title_property)) {
+                //TODO Remove ?
+                // $title_property should not be callable as the method explicitely says it retrieves a property name
+                // and can be used a generic way to get it
+                return $title_property($this);
+            } elseif (is_string($title_property)) {
+                return $this->{$title_property};
+            }
         }
 
         return null;


### PR DESCRIPTION
As it is said in the comment, the title_item() method allow to define a callback to define title_property in a way that this callback would retrieve a value instead of a property.
In my opinion, this is a mistake. Let's consider something like building a query and doing something like ->order_by($class::title_property()) : could be great but does not work with a callback. Even if the callback is executed before (would do orber_by(value) instead of order_by(property)).

I kept this piece of code as I do not know if it's used and do not want to introduce a breaking change. Should be done later though.
