### PR TITLE
Add possibility to override contexts, locales and sites in an appdesk config

### DIFF
--- a/framework/classes/controller/admin/appdesk.ctrl.php
+++ b/framework/classes/controller/admin/appdesk.ctrl.php
@@ -100,7 +100,7 @@ class Controller_Admin_Appdesk extends Controller_Admin_Application
 
     public static function process_config($application, $config)
     {
-        $valid_keys = array('model', 'css', 'notify', 'query', 'search_text', 'dataset', 'selectedView', 'views', 'appdesk', 'tree', 'configuration_id', 'inputs', 'hideContexts', 'i18n', 'custom');
+        $valid_keys = array('model', 'css', 'notify', 'query', 'search_text', 'dataset', 'selectedView', 'views', 'appdesk', 'tree', 'configuration_id', 'inputs', 'hideContexts', 'i18n', 'custom', 'contexts', 'locales', 'sites');
         if (isset($config['model'])) {
             $config['model'] = ltrim($config['model'], '\\');
             $namespace_model = \Inflector::get_namespace($config['model']);


### PR DESCRIPTION
Use case: disable the "switch context" feature on an appdesk by setting a single context in the "contexts" appdesk configuration key.
