### PR TITLE
allow to call enhancer previews thanks to an hmvc call

### DIFF
--- a/framework/classes/controller/admin/enhancer.ctrl.php
+++ b/framework/classes/controller/admin/enhancer.ctrl.php
@@ -134,6 +134,12 @@ class Controller_Admin_Enhancer extends \Nos\Controller_Admin_Application
                 'enhancer_args' => $args,
             ), false)->render(),
         );
-        \Response::json($body);
+        
+        //As action_save() is called by action_preview() and a preview can be built through hmvc,
+        //then only send content when it's not
+        if (!\Request::is_hmvc()) {
+            \Response::json($body);
+        }
+        return $body['preview'];
     }
 }


### PR DESCRIPTION
Evenn if it seemed odd at first, I decided to use a "not" in "if not hmvc" so that the method ends with the "return" statement.

Note 1 : To make this efficient, action_save() must return content when it's overridden.

Note 2 : was'nt sure of doing it for Elche or other version; made it only for the latest as it's a new feature and not a bugfix
