### PR TITLE
Fix warning when template not found

### DIFF
--- a/framework/applications/noviusos_template_variation/classes/model/template/variation.model.php
+++ b/framework/applications/noviusos_template_variation/classes/model/template/variation.model.php
@@ -149,7 +149,7 @@ class Model_Template_Variation extends \Nos\Orm\Model
             $template_metadata = \Arr::get($templates, $this->tpvar_template, array());
             $config = array_merge(
                 $template_metadata,
-                \Config::load($template_metadata['application'].'::variation/'.$this->tpvar_template, true)
+                \Config::load(\Arr::get($template_metadata, 'application').'::variation/'.$this->tpvar_template, true)
             );
 
             $callables = array(

--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -820,7 +820,7 @@ class Controller_Front extends Controller
         if (empty($this->_template['file'])) {
             throw new \Exception(
                 'The template file for '.
-                ($this->_template['title'] ?: $this->_page->template_variation->tpvar_template ).' is not defined.'
+                (\Arr::get($this->_template, 'title') ?: $this->_page->template_variation->tpvar_template ).' is not defined.'
             );
         }
 


### PR DESCRIPTION
When something is wrong with a template (eg. template file not found for a template variation) there are some warnings due to undefined array keys. Use \Arr::get() to prevent theses warnings.
