### PR TITLE
Change where the auto-id is done

### DIFF
--- a/framework/classes/fuel/fieldset.php
+++ b/framework/classes/fuel/fieldset.php
@@ -496,7 +496,7 @@ class Fieldset extends \Fuel\Core\Fieldset
         }
     }
 
-    public function populate_with_instance($instance = null, $generate_id = true)
+    public function populate_with_instance($instance = null, $generate_id = false)
     {
         $this->instance = $instance;
 

--- a/framework/classes/fuel/fieldset_field.php
+++ b/framework/classes/fuel/fieldset_field.php
@@ -40,7 +40,7 @@ class Fieldset_Field extends \Fuel\Core\Fieldset_Field
     public function generate_auto_id()
     {
         $form = $this->fieldset()->form();
-        if ($form->get_config('auto_id', false) === true and $this->get_attribute('id') == '') {
+        if ($form->get_config('auto_id', true) === true and $this->get_attribute('id') == '') {
             $auto_id = $form->get_config('auto_id_prefix', '').str_replace(array('[', ']', '->'), array('-', '', '_'), $this->name);
             $this->set_attribute('id', $auto_id);
         }


### PR DESCRIPTION
Default config was always erasing ids. The default "auto-id" option now take into account whether the id has been specified or not.

From what I saw, it does not break anything, but it might be good to double check.
