### PR TITLE
Twinnable HasMany : unset on main relation

### DIFF
--- a/framework/classes/orm/twinnable/hasmany.php
+++ b/framework/classes/orm/twinnable/hasmany.php
@@ -213,7 +213,6 @@ class Orm_Twinnable_HasMany extends \Orm\HasMany
             $models[$rel_name_main]['primary_key'] = $props_pks['primary_key'];
             $models[$rel_name_main]['columns'] = $props_pks['columns'];
         } else {
-            unset($models[$rel_name_main]);
             $models[$rel_name_context]['primary_key'] = call_user_func(array($this->model_to, 'primary_key'));
             $models[$rel_name_context]['columns'] = $this->select($alias_to_context);
         }


### PR DESCRIPTION
It  mustn't be done as there is a "join on" condition on it.
