### PR TITLE
only remove relative dir when the request URI begins with it

### DIFF
--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -247,7 +247,7 @@ chdir(DOCROOT);
 
 // Remove leading /
 $_SERVER['NOS_URL'] = mb_substr(urldecode($_SERVER['REQUEST_URI']), 1);
-if (defined('NOS_RELATIVE_DIR')) {
+if (defined('NOS_RELATIVE_DIR') && \Str::starts_with($_SERVER['NOS_URL'], NOS_RELATIVE_DIR)) {
     $_SERVER['NOS_URL'] = mb_substr($_SERVER['NOS_URL'], mb_strlen(NOS_RELATIVE_DIR));
 }
 list($_SERVER['NOS_URL']) = explode('?', $_SERVER['NOS_URL']);


### PR DESCRIPTION
It created some side effects when asking for files or media in cache. 
(Request URI began with path instead of beginning with possible subdomain name)
