### PR TITLE
Don't reorder when retrieving the list of contexts available to the connected user

### DIFF
--- a/framework/applications/noviusos_user/classes/permission.php
+++ b/framework/applications/noviusos_user/classes/permission.php
@@ -135,7 +135,7 @@ class Permission
             if (empty($allowedContexts)) {
                 return array();
             }
-            $contexts = array_intersect_key(array_combine($allowedContexts, $allowedContexts), $contexts);
+            $contexts = array_intersect_key($contexts, array_combine($allowedContexts, $allowedContexts));
         }
 
         return $contexts;


### PR DESCRIPTION
This change affects the contexts list-selector because they're already "developer" ordered in the tick boxes tables, so this adds coherence in how both context selectors behave.

Switching around array_intersect_key's arguments will keep the developer-defined order (eg. define a default context that is not alphabetically first).
