### PR TITLE
Prevents an error when getting the main_controller without any main request

### DIFF
--- a/framework/classes/nos.php
+++ b/framework/classes/nos.php
@@ -41,7 +41,11 @@ class Nos
      */
     public static function main_controller()
     {
-        return \Request::main()->controller_instance;
+        $request = \Request::main();
+        if (empty($request)) {
+            return null;
+        }
+        return $request->controller_instance;
     }
 
     /**


### PR DESCRIPTION
Prevents \Nos\Nos::main_controller() to throw an error when there is no main request (eg. in a custom script)
