### PR TITLE
Current context as default context in multi-content sites

### DIFF
--- a/framework/classes/tools/context.php
+++ b/framework/classes/tools/context.php
@@ -72,6 +72,11 @@ class Tools_Context
         return static::$_contexts;
     }
 
+    public static function useCurrentContext() {
+        \Config::load('contexts', true);
+        return \Config::get('contexts.use_current', false);
+    }
+
     /**
      * get an array of all sites Novius OS instance
      *

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -117,7 +117,7 @@ class Tools_Enhancer
         }
 
         // Get the current context if the context parameter is not specified and we have more than one context
-        if (!$context) {
+        if (!$context && Tools_Context::useCurrentContext()) {
             $contexts = Tools_Context::contexts();
             if (count($contexts) > 1) {
                 $controller = Nos::main_controller();

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -115,6 +115,15 @@ class Tools_Enhancer
                 }
             }
         }
+
+        // Get the current context if the context parameter is not specified and we have more than one context
+        if (!$context) {
+            $contexts = Tools_Context::contexts();
+            if (count($contexts) > 1) {
+                $context = Nos::main_controller()->getContext();
+            }
+        }
+
         $empty_params = !count(array_diff_key(
             $params,
             array('context' => null, 'urlPath' => null, 'preview' => null)

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -120,7 +120,10 @@ class Tools_Enhancer
         if (!$context) {
             $contexts = Tools_Context::contexts();
             if (count($contexts) > 1) {
-                $context = Nos::main_controller()->getContext();
+                $controller = Nos::main_controller();
+                if (!empty($controller)) {
+                    $context = $controller->getContext();
+                }
             }
         }
 


### PR DESCRIPTION
Made a small change in Tools_Enhancer::url to use the current context as default value when context is not specified and we are in a multiple contexts NOS instance.

This is particularly usefull when enabling multiple contexts in a single context site and will ease the use of Tools_Enhancer.
