### PR TITLE
Call parrent::_init() to prevent the Virtual Name behaviour to be load without the friendly slug config

### DIFF
--- a/framework/classes/orm/behaviour/virtualpath.php
+++ b/framework/classes/orm/behaviour/virtualpath.php
@@ -14,7 +14,7 @@ class Orm_Behaviour_Virtualpath extends Orm_Behaviour_Virtualname
 {
     public static function _init()
     {
-        I18n::current_dictionary('nos::orm');
+        parent::_init();
     }
 
     protected $_parent_relation = null;

--- a/framework/classes/orm/behaviour/virtualpath.php
+++ b/framework/classes/orm/behaviour/virtualpath.php
@@ -14,6 +14,7 @@ class Orm_Behaviour_Virtualpath extends Orm_Behaviour_Virtualname
 {
     public static function _init()
     {
+        I18n::current_dictionary('nos::orm');
         parent::_init();
     }
 


### PR DESCRIPTION
With the NOS autoloader (`/novius-os/framework/classes/fuel/autoloader.php`) if a class which is entended by another is load as the parent of a class, the `_init()` method of the parent class is not call (due to the value of `Autoloader::$auto_initialize`).

To avoid this, it is necessary to always call the `parent::_init()` method of a class when it exist.
