### PR TITLE
Use publication_start_property to sort

### DIFF
--- a/framework/classes/orm/behaviour/publishable.php
+++ b/framework/classes/orm/behaviour/publishable.php
@@ -120,7 +120,7 @@ class Orm_Behaviour_Publishable extends Orm_Behaviour
 
             return array($where);
         };
-        $options['before_order_by']['published'] = $_properties['publication_state_property'];
+        $options['before_order_by']['published'] = $_properties['publication_start_property'];
     }
 
     public function form_processing(Orm\Model $item, $data, $response_json)
@@ -141,6 +141,11 @@ class Orm_Behaviour_Publishable extends Orm_Behaviour
             if ($status == 2 && empty($publication_start) && empty($publication_end)) {
                 // Unpublish
                 $status = 0;
+            }
+
+            // Set publication start to now if published without schedule
+            if ($status == 1) {
+                $item->set($publication_start_property, (new Date(strtotime('now')))->format('mysql'));
             }
         }
         $item->set($publishable, $status);

--- a/framework/classes/orm/behaviour/publishable.php
+++ b/framework/classes/orm/behaviour/publishable.php
@@ -145,7 +145,7 @@ class Orm_Behaviour_Publishable extends Orm_Behaviour
 
             // Set publication start to now if published without schedule
             if ($status == 1) {
-                $item->set($publication_start_property, (new Date(strtotime('now')))->format('mysql'));
+                $item->set($publication_start_property, (new \Date(strtotime('now')))->format('mysql'));
             }
         }
         $item->set($publishable, $status);

--- a/framework/classes/orm/behaviour/publishable.php
+++ b/framework/classes/orm/behaviour/publishable.php
@@ -120,7 +120,8 @@ class Orm_Behaviour_Publishable extends Orm_Behaviour
 
             return array($where);
         };
-        $options['before_order_by']['published'] = $_properties['publication_start_property'];
+        $options['before_order_by']['published'] = $_properties['publication_state_property'];
+        $options['before_order_by']['published_at'] = $_properties['publication_start_property'];
     }
 
     public function form_processing(Orm\Model $item, $data, $response_json)
@@ -144,8 +145,8 @@ class Orm_Behaviour_Publishable extends Orm_Behaviour
             }
 
             // Set publication start to now if published without schedule
-            if ($status == 1) {
-                $item->set($publication_start_property, (new \Date(strtotime('now')))->format('mysql'));
+            if (!$item->get($publication_start_property) && $status == 1) {
+                $item->set($publication_start_property, (new \Date())->format('mysql'));
             }
         }
         $item->set($publishable, $status);


### PR DESCRIPTION
Sorting on publication state (0,1,2) seems pointless. Sorting on publication start allows to get newest item without knowing the column name ('published' => 'DESC').
For this to work we also have to set publication_start to now on save if state == 1 (aka permanent publication).

EDIT: Added a new sort published_at, example usage : `'order_by' => array('published_at' => 'DESC')`.
