### PR TITLE
Force the LC_CTYPE local to en_GB when tr_TR is used

### DIFF
--- a/framework/classes/i18n.php
+++ b/framework/classes/i18n.php
@@ -118,6 +118,15 @@ class I18n
             static::$_locale.'@'.$variant,
             static::$_locale,
         ));
+        //Prevent the tr_TR local problems (see https://bugs.php.net/bug.php?id=18556 )
+        if (static::$_locale == 'tr_TR') {
+            setlocale(LC_CTYPE, array(
+                'en_GB.'.static::$_encoding.'@'.$variant,
+                'en_GB.'.static::$_encoding,
+                'en_GB@'.$variant,
+                'en_GB'
+            ));
+        }
     }
 
     /**


### PR DESCRIPTION
This allow to avoid the characters problem.
You can learn more here : https://bugs.php.net/bug.php?id=18556
