### PR TITLE
Allow using inspector modeltree to handle sorting without behaviour tree

### DIFF
--- a/framework/classes/controller.php
+++ b/framework/classes/controller.php
@@ -539,11 +539,13 @@ class Controller extends \Fuel\Core\Controller_Hybrid
             );
         }
 
-        \Response::json(
-            array(
-                'success' => true,
-            )
+        $json = array(
+            'success' => true,
         );
+        if (empty($behaviour_tree)) {
+            $json['no_tree'] = true;
+        }
+        \Response::json($json);
     }
 
     public function tree_selected(array $tree_config, array $params)

--- a/framework/classes/controller.php
+++ b/framework/classes/controller.php
@@ -509,7 +509,9 @@ class Controller extends \Fuel\Core\Controller_Hybrid
                     $parent = $parent->find_context($from->get_context());
                 }
                 $from->set_parent($parent);
-            }
+            } elseif ($params['targetType'] === 'in') {
+				$params['targetType'] = 'after';
+			}
 
             // Change sort order
             $behaviour_sort = $model_from::behaviours('Nos\Orm_Behaviour_Sortable');

--- a/framework/classes/controller.php
+++ b/framework/classes/controller.php
@@ -510,8 +510,8 @@ class Controller extends \Fuel\Core\Controller_Hybrid
                 }
                 $from->set_parent($parent);
             } elseif ($params['targetType'] === 'in') {
-				$params['targetType'] = 'after';
-			}
+            	$params['targetType'] = 'after';
+            }
 
             // Change sort order
             $behaviour_sort = $model_from::behaviours('Nos\Orm_Behaviour_Sortable');

--- a/static/admin/novius-os/js/jquery.novius-os.treegrid.js
+++ b/static/admin/novius-os/js/jquery.novius-os.treegrid.js
@@ -467,7 +467,7 @@ define('jquery-nos-treegrid',
                     success : function (data, textStatus) {
                         if (data.success) {
                             self.draggedIndex = false;
-                            if (self.dropTarget === 'in') {
+                            if ((self.dropTarget === 'in') && (typeof data.no_tree == 'undefined')) {
                                 self._removeNode(dragNode);
                                 self._toggle(dropped, true);
                             } else {


### PR DESCRIPTION
As it's called "Modeltree", the model should indeed behave like a tree.
However, the ability to sort on an inspector Model was missing, and the modeltree does handle sorting actions properly.
On line 505, there's even a test made to know if the model has the behaviour, without throwing an error if not.

**Other things I saw during this implementation** :
- **Nos\Controller** : `tree_move()` uses `Response::json()`, wich prevents `tree()` to return anything (_l.383 same controller_), wich also prevents `action_json()` to deal with the returned json (_l.38 on Nos\Controller_Inspector_Modeltree_)
- **Nos\Controller_Inspector_Modeltree** : add default condition to build roots, without using behaviour configuration. Should do, but I fear it'd be a breaking change for those who used the controller without the behaviour (even if it should not working well without this PR).
