### PR TITLE
Event before_parse_wysiwig

### DIFF
--- a/framework/classes/tools/wysiwyg.php
+++ b/framework/classes/tools/wysiwyg.php
@@ -64,6 +64,8 @@ class Tools_Wysiwyg
 
         \Fuel::$profiling && \Profiler::mark('Recherche des fonctions dans la page');
 
+        \Event::trigger_function('front.before_parse_wysiwyg', array(&$content));
+
         $callback = array('Nos\Tools_Enhancer', 'content');
         static::parseEnhancers(
             $content,


### PR DESCRIPTION
In order to be able to edit medias or enhancers or stuff like that we need an event before parsing them.
