### PR TITLE
Preview url in the selected context + Tools_Enhancer use first defined context as fallback

### DIFF
--- a/framework/classes/controller/admin/appdesk.ctrl.php
+++ b/framework/classes/controller/admin/appdesk.ctrl.php
@@ -41,6 +41,25 @@ class Controller_Admin_Appdesk extends Controller_Admin_Application
         return $this->config;
     }
 
+    /**
+     * Gets the current context. If there are multiple contexts, gets the first one.
+     *
+     * @return mixed|null
+     */
+    public function getContext() {
+        $selected_contexts = $this->getSelectedContexts();
+        return !empty($selected_contexts) ? reset($selected_contexts) : null;
+    }
+
+    /**
+     * Get the selected contexts
+     *
+     * @return mixed|null
+     */
+    public function getSelectedContexts() {
+        return (array) \Arr::get($this->config, 'selectedContexts', array());
+    }
+
     public function action_index($view = null)
     {
         if (empty($view)) {

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -120,9 +120,14 @@ class Tools_Enhancer
         if (!$context && Tools_Context::useCurrentContext()) {
             $contexts = Tools_Context::contexts();
             if (count($contexts) > 1) {
-                $controller = Nos::main_controller();
-                if (!empty($controller)) {
-                    $context = $controller->getContext();
+                // Try to get the current context from the main controller
+                if (Nos::main_controller() && method_exists(Nos::main_controller(), 'getContext')) {
+                    $context = Nos::main_controller()->getContext();
+                }
+                // Otherwise use the first defined context as default context
+                else {
+                    reset($contexts);
+                    $context = key($contexts);
                 }
             }
         }


### PR DESCRIPTION
Add a `getContext()` method on `Controller_Admin_Appdesk` that returns the current selected context (or the first one if there are multiple selected contexts).

`Tools_Enhancer::_urls()` now checks if `getContext()` exists on the main controller before calling it.

If it's not possible to determine the current context, `Tools_Enhancer::_urls()` now uses the first defined context instead of using the first url found for the enhancer. I'm not sure I'm not breaking something by doing this, further tests/opinions would be useful.

Only those who enabled `contexts.use_current` in the contexts configuration file should be affected by this PR.
