### PR TITLE
Create folder if not exists when moving folder

### DIFF
--- a/framework/applications/noviusos_media/classes/controller/admin/folder.ctrl.php
+++ b/framework/applications/noviusos_media/classes/controller/admin/folder.ctrl.php
@@ -31,6 +31,11 @@ class Controller_Admin_Folder extends \Nos\Controller_Admin_Crud
         if (!$folder->is_new()) {
             if ($folder->path() != $this->clone->path()) {
                 if (is_dir($this->clone->path())) {
+                    if (!is_dir($folder->path())) {
+                        $base_dir = APPPATH.Model_Media::$private_path;
+                        $remaining_dir = str_replace($base_dir, '', $folder->path());
+                        \File::create_dir($base_dir, $remaining_dir, 0777);
+                    }
                     if (!\File::rename_dir($this->clone->path(), $folder->path())) {
                         $folder->medif_path = $this->clone->medif_path;
                     }


### PR DESCRIPTION
There is a little bug in the media center when you try to move a filled folder into an empty one which was always empty.

As of now it tries to copy the moved folder's local/data/media directory into the new parent's one and subsequently fails because the folder doesn't exists since it's only created when adding media to this folder.
