### PR TITLE
Fix the folder creation in the mass upload controller

### DIFF
--- a/framework/applications/noviusos_media/classes/controller/admin/upload.ctrl.php
+++ b/framework/applications/noviusos_media/classes/controller/admin/upload.ctrl.php
@@ -114,8 +114,8 @@ class Controller_Admin_Upload extends \Nos\Controller_Admin_Application
             try {
                 if (is_array($file)) {
                     $name   = rtrim($dir, '/');
-                    $folder = $this->_importFolder($name, $folder);
-                    $this->_importFiles($file, $path . $dir, $folder);
+                    $new_folder = $this->_importFolder($name, $folder);
+                    $this->_importFiles($file, $path . $dir, $new_folder);
                 } else {
                     $pathinfo = pathinfo($file);
                     if (!in_array(\Str::lower($pathinfo['extension']), static::$_disallowed_extensions)) {


### PR DESCRIPTION
Fix an issue when uploading a zip file containing multiple folders (each folder was added to the previously created folder).
