### PR TITLE
Use query's connection instance to quote identifiers

### DIFF
--- a/framework/classes/controller.php
+++ b/framework/classes/controller.php
@@ -195,7 +195,7 @@ class Controller extends \Fuel\Core\Controller_Hybrid
         $select = \Arr::get($model::primary_key(), 0);
         $select = (mb_strpos($select, '.') === false ? $query->alias().'.'.$select : $select);
         // Get the columns
-        $columns = \DB::expr('DISTINCT '.\Database_Connection::instance()->quote_identifier($select).' AS group_by_pk');
+        $columns = \DB::expr('DISTINCT '.\Database_Connection::instance($query->connection())->quote_identifier($select).' AS group_by_pk');
         // Remove the current select and
         $new_query = call_user_func('DB::select', $columns);
         // Set from table


### PR DESCRIPTION
By not using the query's connection you get errors like this on the appdesk if the model uses another connection than the site's default:

```
Unknown column 't0.id' in 'field list' [ SELECT DISTINCT `t0`.`id` AS group_by_pk FROM `{prefix}{table}` AS `{prefix}t0` GROUP BY `group_by_pk` LIMIT 16 ]
```

Using the correct connection you expect to get this query:

```
SELECT DISTINCT `{prefix}t0`.`id` AS group_by_pk FROM `{prefix}{table}` AS `{prefix}t0` GROUP BY `group_by_pk` LIMIT 16
```
