### PR TITLE
Allow successive migration initializations to start fresh

### DIFF
--- a/framework/classes/fuel/migrate.php
+++ b/framework/classes/fuel/migrate.php
@@ -34,6 +34,10 @@ class Migrate extends \Fuel\Core\Migrate
             \Config::set('migrations.version', array());
             \Config::set('migrations.table', 'nos_migration');
         }
+
+        // Reset internal state
+        static::$migrations = array();
+
         parent::_init();
     }
 


### PR DESCRIPTION
Basically reload state from db when you call Migrate::_init() instead of keeping possibly stale data from static.
