### PR TITLE
Set correct sort for duplicated pages

### DIFF
--- a/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
+++ b/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
@@ -314,12 +314,14 @@ class Controller_Admin_Page extends \Nos\Controller_Admin_Crud
                     $clone->page_title = $main->page_title.$title_append;
                     $clone->page_virtual_name = null;
                     $clone->page_virtual_url = null;
-                    $lastPage = Model_Page::query()
-                        ->where('page_parent_id', $clone->page_parent_id)
-                        ->order_by('page_sort', 'DESC')
-                        ->limit(1)
-                        ->get_one();
-                    $clone->page_sort = $lastPage->page_sort + 1;
+                    if ($clone->behaviours('Nos\Orm_Behaviour_Sortable')) {
+                        $lastPage = Model_Page::query()
+                            ->where('page_parent_id', $clone->page_parent_id)
+                            ->order_by('page_sort', 'DESC')
+                            ->limit(1)
+                            ->get_one();
+                        $clone->move_after($lastPage);
+                    }
                 }
                 $clone->save();
                 break;

--- a/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
+++ b/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
@@ -314,7 +314,11 @@ class Controller_Admin_Page extends \Nos\Controller_Admin_Crud
                     $clone->page_title = $main->page_title.$title_append;
                     $clone->page_virtual_name = null;
                     $clone->page_virtual_url = null;
-                    $lastPage = Model_Page::query()->order_by('page_sort', 'DESC')->limit(1)->get_one();
+                    $lastPage = Model_Page::query()
+                        ->where('page_parent_id', $clone->page_parent_id)
+                        ->order_by('page_sort', 'DESC')
+                        ->limit(1)
+                        ->get_one();
                     $clone->page_sort = $lastPage->page_sort + 1;
                 }
                 $clone->save();

--- a/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
+++ b/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
@@ -315,12 +315,7 @@ class Controller_Admin_Page extends \Nos\Controller_Admin_Crud
                     $clone->page_virtual_name = null;
                     $clone->page_virtual_url = null;
                     if ($clone->behaviours('Nos\Orm_Behaviour_Sortable')) {
-                        $lastPage = Model_Page::query()
-                            ->where('page_parent_id', $clone->page_parent_id)
-                            ->order_by('page_sort', 'DESC')
-                            ->limit(1)
-                            ->get_one();
-                        $clone->move_after($lastPage);
+                        $clone->move_to_last_position();
                     }
                 }
                 $clone->save();

--- a/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
+++ b/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
@@ -314,6 +314,8 @@ class Controller_Admin_Page extends \Nos\Controller_Admin_Crud
                     $clone->page_title = $main->page_title.$title_append;
                     $clone->page_virtual_name = null;
                     $clone->page_virtual_url = null;
+                    $lastPage = Model_Page::query()->order_by('page_sort', 'DESC')->limit(1)->get_one();
+                    $clone->page_sort = $lastPage->page_sort + 1;
                 }
                 $clone->save();
                 break;

--- a/framework/classes/orm/behaviour/sortable.php
+++ b/framework/classes/orm/behaviour/sortable.php
@@ -42,7 +42,20 @@ class Orm_Behaviour_Sortable extends Orm_Behaviour
 
     public function move_to_last_position($item)
     {
-        $this->_move($item, 10000);
+        $itemClass = get_class($item);
+        $lastPage = $itemClass::query()
+            ->order_by($this->_properties['sort_property'], 'DESC')
+            ->limit(1);
+        $tree = $item->behaviours('Nos\Orm_Behaviour_Tree');
+        if (!empty($tree)) {
+            $lastPage->where('parent', $item->get_parent());
+        }
+        $lastPage = $lastPage->get_one();
+        if ($lastPage) {
+        $this->move_after($item, $lastPage);
+        } else {
+            $this->_move($item, 1);
+        }
     }
 
     public function get_sort(\Nos\Orm\Model $item)

--- a/framework/classes/orm/behaviour/sortable.php
+++ b/framework/classes/orm/behaviour/sortable.php
@@ -43,16 +43,16 @@ class Orm_Behaviour_Sortable extends Orm_Behaviour
     public function move_to_last_position($item)
     {
         $itemClass = get_class($item);
-        $lastPage = $itemClass::query()
+        $lastItem = $itemClass::query()
             ->order_by($this->_properties['sort_property'], 'DESC')
             ->limit(1);
         $tree = $item->behaviours('Nos\Orm_Behaviour_Tree');
         if (!empty($tree)) {
-            $lastPage->where('parent', $item->get_parent());
+            $lastItem->where('parent', $item->get_parent());
         }
-        $lastPage = $lastPage->get_one();
-        if ($lastPage) {
-        $this->move_after($item, $lastPage);
+        $lastItem = $lastItem->get_one();
+        if ($lastItem) {
+        $this->move_after($item, $lastItem);
         } else {
             $this->_move($item, 1);
         }


### PR DESCRIPTION
There is a bug when duplicating top level page that keeps the page_sort value from the original page.

With this fix the sort value will always been put to the last one.
