### PR TITLE
Populate array-type fields

### DIFF
--- a/framework/classes/fuel/fieldset.php
+++ b/framework/classes/fuel/fieldset.php
@@ -528,15 +528,7 @@ class Fieldset extends \Fuel\Core\Fieldset
             if ($populateCallback && is_callable($populateCallback)) {
                 $populate[$k] = call_user_func($populateCallback, $instance);
                 if (strpos($k, ']')) {
-                    $members = array_filter(explode('[', str_replace(']', '', $k)));
-                    $array = array();
-                    $arrayPtr = &$array;
-                    foreach ($members as $member) {
-                        $arrayPtr[$member] = array();
-                        $arrayPtr = &$arrayPtr[$member];
-                    }
-                    $arrayPtr = $populate[$k];
-                    $populate = \Arr::merge_assoc($populate, $array);
+                    \Arr::set($populate, strtr($k, array('[' => '.', ']' => '')), $populate[$k]);
                 }
                 continue;
             }

--- a/framework/classes/fuel/fieldset.php
+++ b/framework/classes/fuel/fieldset.php
@@ -536,7 +536,7 @@ class Fieldset extends \Fuel\Core\Fieldset
                         $arrayPtr = &$arrayPtr[$member];
                     }
                     $arrayPtr = $populate[$k];
-                    $populate = \Arr::merge($populate, $array);
+                    $populate = \Arr::merge_assoc($populate, $array);
                 }
                 continue;
             }

--- a/framework/classes/fuel/fieldset.php
+++ b/framework/classes/fuel/fieldset.php
@@ -527,6 +527,17 @@ class Fieldset extends \Fuel\Core\Fieldset
             $populateCallback = \Arr::get($this->config_used, "$k.populate");
             if ($populateCallback && is_callable($populateCallback)) {
                 $populate[$k] = call_user_func($populateCallback, $instance);
+                if (strpos($k, ']')) {
+                    $members = array_filter(explode('[', str_replace(']', '', $k)));
+                    $array = array();
+                    $arrayPtr = &$array;
+                    foreach ($members as $member) {
+                        $arrayPtr[$member] = array();
+                        $arrayPtr = &$arrayPtr[$member];
+                    }
+                    $arrayPtr = $populate[$k];
+                    $populate = \Arr::merge($populate, $array);
+                }
                 continue;
             }
 


### PR DESCRIPTION
There is a bug when you have a field named as an array (eg: list[field][value]) and you want to populate it, it's mainly due to the way that fuel change the name of the field to an array when populating it while nOS keeps the whole name as the value.

nOS will put 

``` php
"list[field][value]" => 42
```

And fuel will try to find list.field.value.

With this modification i add the data wanted by fuel in the $populate array.
