### PR TITLE
Use the only view when no other is configured

### DIFF
--- a/framework/applications/noviusos_menu/config/controller/admin/menu/enhancer.config.php
+++ b/framework/applications/noviusos_menu/config/controller/admin/menu/enhancer.config.php
@@ -45,7 +45,7 @@ return array(
                 'type' => count($views) > 1 ? 'select' : 'hidden',
                 'class' => 'menu_view',
                 'options' => $views,
-                'value' => array_keys($views)[0],
+                'value' => key($views),
             ),
         ),
     ),

--- a/framework/applications/noviusos_menu/config/controller/admin/menu/enhancer.config.php
+++ b/framework/applications/noviusos_menu/config/controller/admin/menu/enhancer.config.php
@@ -45,6 +45,7 @@ return array(
                 'type' => count($views) > 1 ? 'select' : 'hidden',
                 'class' => 'menu_view',
                 'options' => $views,
+                'value' => array_keys($views)[0],
             ),
         ),
     ),


### PR DESCRIPTION
When there is only one view configured for the menu enhancer, it would not pass it through to the front, resulting in an empty display.
