### PR TITLE
Bugfix cache_duration if page_cache_duration is set in page

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -329,6 +329,7 @@ class Controller_Front extends Controller
             if (!empty($this->_page->page_cache_duration)) {
                 $this->_cache_duration = $this->_page->page_cache_duration;
                 \Nos\FrontCache::$cache_duration = $this->_cache_duration;
+                \Nos\FrontCache::$cache_duration_page_id = $this->_page->page_id;
             }
         }
 

--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -26,6 +26,7 @@ class FrontCache
     protected static $_php_begin = null;
 
     public static $cache_duration = 60;
+    public static $cache_duration_page_id = null;
 
     /**
      * @var bool True when executing cache, to prevent echoing uncache strings
@@ -251,12 +252,14 @@ class FrontCache
         $this->_level = ob_get_level();
     }
 
-    public static function checkExpires($expires, $initial_cache_duration = 0)
+    public static function checkExpires($expires, $initial_cache_duration = 0, $cache_duration_page_id = null)
     {
         if ($expires > 0 && $expires <= time()) {
             throw new CacheExpiredException();
         }
-        if ($initial_cache_duration > static::$cache_duration) {
+        // Check if cache duration change
+        // if page_cache_duration is set, $cache_duration_page_id contains page_id ; in this case, we ignore that test
+        if (empty($cache_duration_page_id) && $initial_cache_duration > static::$cache_duration) {
             throw new CacheExpiredException();
         }
     }
@@ -273,7 +276,7 @@ class FrontCache
             $expires = time() + $duration;
             $prepend .= '<?php
 
-            '.__CLASS__.'::checkExpires('.$expires.', '.$duration.');'."\n";
+            '.__CLASS__.'::checkExpires('.$expires.', '.$duration.', '.(int) static::$cache_duration_page_id.');'."\n";
 
             if (!empty($controller)) {
                 if ($this->_path === $this->_init_path && !empty($this->_suffix_handlers)) {


### PR DESCRIPTION
If page_cache_duration is set, this test has to be ignored, because static::$cache_duration contains config cache duration instead of page_cache_duration (we can't read this value into DB for performance reasons) :

 if ($initial_cache_duration > static::$cache_duration) {
     throw new CacheExpiredException();
 }
