### PR TITLE
Use preview input when building enhancer urls

### DIFF
--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -84,7 +84,7 @@ class Tools_Enhancer
 
         $urlPath = \Arr::get($params, 'urlPath', false);
         $mainController = Nos::main_controller();
-        $preview = \Arr::get($params, 'preview', (NOS_ENTRY_POINT === Nos::ENTRY_POINT_FRONT && !empty($mainController) && method_exists($mainController, 'isPreview') ? Nos::main_controller()->isPreview() : false));
+        $preview = \Arr::get($params, 'preview', (!empty($mainController) && method_exists($mainController, 'isPreview') ? Nos::main_controller()->isPreview() : false));
 
         $callback = array($namespace.'\\'.$controller_name, 'getUrlEnhanced');
 

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -83,7 +83,7 @@ class Tools_Enhancer
         $url_enhanced = Config_Data::get('url_enhanced', array());
 
         $urlPath = \Arr::get($params, 'urlPath', false);
-        $preview = \Arr::get($params, 'preview', \Input::get('_preview', false));
+        $preview = \Arr::get($params, 'preview', (NOS_ENTRY_POINT === Nos::ENTRY_POINT_FRONT ? Nos::main_controller()->isPreview() : false));
 
         $callback = array($namespace.'\\'.$controller_name, 'getUrlEnhanced');
 

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -83,7 +83,8 @@ class Tools_Enhancer
         $url_enhanced = Config_Data::get('url_enhanced', array());
 
         $urlPath = \Arr::get($params, 'urlPath', false);
-        $preview = \Arr::get($params, 'preview', (NOS_ENTRY_POINT === Nos::ENTRY_POINT_FRONT ? Nos::main_controller()->isPreview() : false));
+        $mainController = Nos::main_controller();
+        $preview = \Arr::get($params, 'preview', (NOS_ENTRY_POINT === Nos::ENTRY_POINT_FRONT && !empty($mainController) && method_exists($mainController, 'isPreview') ? Nos::main_controller()->isPreview() : false));
 
         $callback = array($namespace.'\\'.$controller_name, 'getUrlEnhanced');
 

--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -83,7 +83,7 @@ class Tools_Enhancer
         $url_enhanced = Config_Data::get('url_enhanced', array());
 
         $urlPath = \Arr::get($params, 'urlPath', false);
-        $preview = \Arr::get($params, 'preview', false);
+        $preview = \Arr::get($params, 'preview', \Input::get('_preview', false));
 
         $callback = array($namespace.'\\'.$controller_name, 'getUrlEnhanced');
 


### PR DESCRIPTION
I take the preview parameter by default instead of false. That way in a preview context, we can build url to unpublished items.
