### PR TITLE
Uses the defined prefix before generating one from the primary key

### DIFF
--- a/framework/classes/fuel/orm/model.php
+++ b/framework/classes/fuel/orm/model.php
@@ -708,6 +708,11 @@ class Model extends \Orm\Model
 
     public static function prefix()
     {
+        if (!is_null(static::$_prefix)) {
+            // Uses the defined prefix
+            return static::$_prefix;
+        }
+        // Generates the prefix from the primary key
         return mb_substr(static::$_primary_key[0], 0, mb_strpos(static::$_primary_key[0], '_') + 1);
     }
 


### PR DESCRIPTION
There is a static $_prefix property on the ORM Model but it is never used. When the prefix() method is called it always generates the prefix from the primary_key.

Now if the $_prefix property is defined it will be returned by the prefix() method.
