### PR TITLE
Reset FrontCache::$executing before throwing CacheNotFoundException

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -246,6 +246,7 @@ class FrontCache
                 static::$opcache_invalidate && opcache_invalidate($this->_path, true);
             }
         }
+        self::$executing = false; // We may have executed a higher level page, make sure we don't inline uncached calls
         throw new CacheNotFoundException();
     }
 


### PR DESCRIPTION
Suffixed caches execute after their page's cache, which sets $executing to true, so we have to reset it.
