### PR TITLE
Check correct response class when creation ajax request

### DIFF
--- a/framework/classes/controller.php
+++ b/framework/classes/controller.php
@@ -92,7 +92,7 @@ class Controller extends \Fuel\Core\Controller_Hybrid
 
             // If the response isn't a Response object, embed in the available one for BC
             // @deprecated  can be removed when $this->response is removed
-            if (!$response instanceof Response && $this->response->body == null) {
+            if (!$response instanceof \Response && $this->response->body == null) {
                 $this->response->body = $response;
                 $response = $this->response;
             }


### PR DESCRIPTION
There was a small typo preventing to use cache capabilities when executing an XHR.
