### PR TITLE
Template order consistency

### DIFF
--- a/framework/applications/noviusos_template_variation/config/controller/admin/appdesk.config.php
+++ b/framework/applications/noviusos_template_variation/config/controller/admin/appdesk.config.php
@@ -17,6 +17,13 @@ return array(
     'inspectors' => array(
         'template',
     ),
+    'query' => array(
+        'callback' => array(
+            function ($query) {
+                return $query->order_by('tpvar_default', 'DESC')->order_by('tpvar_title');
+            }
+        )
+    ),
     'appdesk' => array(
         'appdesk' => array(
             'defaultView' => 'thumbnails',

--- a/framework/applications/noviusos_template_variation/config/controller/admin/inspector/template.config.php
+++ b/framework/applications/noviusos_template_variation/config/controller/admin/inspector/template.config.php
@@ -18,13 +18,17 @@ foreach (\Nos\Config_Data::get('templates', array()) as $tpl_key => $template) {
     );
 }
 
+usort($templates, function($a, $b) {
+    return strcmp($a['title'], $b['title']);
+});
+
 return array(
     'data' => $templates,
     'input' => array(
         'key' => 'tpvar_template',
         'query' =>
             function ($value, $query) {
-                $query->where(array('tpvar_template', '=', $value));
+                $query->where(array('tpvar_template', '=', $value))->order_by('tpvar_default', 'DESC')->order_by('tpvar_title');
                 return $query;
             },
     ),


### PR DESCRIPTION
I changed the way templates and variations are displayed in the appdesk to have a better consistency with the nos_page application.

I sort the templates by title, and the variations by title, with the defaut variation as first item. Just like nos_page does it.
