### PR TITLE
Case insensitive on file extension check

### DIFF
--- a/framework/applications/noviusos_media/classes/controller/admin/attachment.ctrl.php
+++ b/framework/applications/noviusos_media/classes/controller/admin/attachment.ctrl.php
@@ -93,7 +93,7 @@ class Controller_Admin_Attachment extends \Nos\Controller_Admin_Application
     protected function attachment($attachment_url)
     {
         $file = false;
-        $match = preg_match('`(.+/)([^/]+)/([^/]+).([a-z]+)$`Uu', $attachment_url, $m);
+        $match = preg_match('`(.+/)([^/]+)/([^/]+).([a-z]+)$`iUu', $attachment_url, $m);
         if ($match) {
             list(, $alias, $attached) = $m;
 

--- a/htdocs/404.php
+++ b/htdocs/404.php
@@ -157,7 +157,7 @@ if ($is_attachment) {
 
     $send_file = false;
     $check = false;
-    $match = preg_match('`(.+/)([^/]+)/([^/]+).([a-z]+)$`Uu', $attachment_url, $m);
+    $match = preg_match('`(.+/)([^/]+)/([^/]+).([a-z]+)$`iUu', $attachment_url, $m);
     if ($match) {
         list(, $alias, $attached, $filename, $extension) = $m;
 


### PR DESCRIPTION
Prevents a 404 error when accessing an attachment having a file extension that contains uppercase characters (because of case sensitive checks).
