### PR TITLE
Keep only the path when selecting the media

### DIFF
--- a/htdocs/404.php
+++ b/htdocs/404.php
@@ -50,7 +50,7 @@ if ($is_media) {
 
     $media = false;
     $res = \DB::select()->from(\Nos\Media\Model_Media::table())->where(array(
-        array('media_path', '=', '/'.$media_url),
+        array('media_path', '=', '/'.parse_url($media_url, PHP_URL_PATH)),
     ))->execute()->as_array();
 
     if (!empty($res)) {


### PR DESCRIPTION
This allows manipulation of the url and information sharing between 404.start and 404.mediaFound by using the query string.
