### PR TITLE
Add a "finally" bloc to force $executing = false if an error occurs

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -244,6 +244,9 @@ class FrontCache
                 ob_end_clean();
                 @unlink($this->_path);
                 static::$opcache_invalidate && opcache_invalidate($this->_path, true);
+            } catch (\Exception $e) {
+                self::$executing = false;
+                throw $e;
             }
         }
         self::$executing = false; // We may have executed a higher level page, make sure we don't inline uncached calls


### PR DESCRIPTION
If an exception is thrown (RuntimeException, CacheNotFoundException...), "self::$executing = false" is never executed. So, if this exception is catched by the application, callHmvcUncached() and viewForgeUncached() methods will be called with "$executing = true", and save unexpected content into cache.

The "finally" bloc is emulated to keep code compatible with PHP 5.3.
