### PR TITLE
Check admin cookie before starting session

### DIFF
--- a/framework/classes/auth.php
+++ b/framework/classes/auth.php
@@ -45,6 +45,13 @@ class Auth
 
     public static function check()
     {
+        // No cookie ? Do not start Session.
+        $sessionConfig = \Config::load('session', true);
+        $sessionCookieName = \Arr::get($sessionConfig, 'file.cookie_name', 'fuelfid');
+        if (!\Cookie::get($sessionCookieName, false) && !\Cookie::get('logged_user_id', false)) {
+            return false;
+        }
+        
         // Might be great to add some additional verifications here !
         $logged_user_id = \Session::get('logged_user_id', false);
         $logged_user_md5 = \Session::get('logged_user_md5', false);

--- a/framework/classes/auth.php
+++ b/framework/classes/auth.php
@@ -46,8 +46,9 @@ class Auth
     public static function check()
     {
         // No cookie ? Do not start Session.
-        $sessionConfig = \Config::load('session', true);
-        $sessionCookieName = \Arr::get($sessionConfig, 'file.cookie_name', 'fuelfid');
+        $sessionConfig      = \Config::load('session', true);
+        $sessionDriver      = \Arr::get($sessionConfig, 'driver', 'file');
+        $sessionCookieName  = \Arr::get($sessionConfig, $sessionDriver.'.cookie_name', 'fuelfid');
         if (!\Cookie::get($sessionCookieName, false) && !\Cookie::get('logged_user_id', false)) {
             return false;
         }


### PR DESCRIPTION
Some applications (like bru_seo_tools) use \Nos::auth() in front-office, in order to check if the current user is an admin. Without this cookie-test, a session is started for every user (admin or not), so pages can't be cached by reverse proxy...
