### PR TITLE
Added callback to customize attachment storage strategy.

### DIFF
--- a/framework/classes/attachment.php
+++ b/framework/classes/attachment.php
@@ -82,7 +82,7 @@ class Attachment
         }
         $config['alias'] = rtrim(str_replace(DS, '/', $config['alias']), '/').'/';
 
-        if(!empty($config['attached_callback']) && is_callable($config['attached_callback'])) {
+        if (!empty($config['attached_callback']) && is_callable($config['attached_callback'])) {
             $attached = $config['attached_callback']($attached, $config);
         } else {
             $attached = preg_replace('`/`Uu', '_', $attached);
@@ -257,7 +257,7 @@ class Attachment
         $path = $this->path();
         $this->attached = $id;
 
-        if(!empty($this->config['attached_callback']) && is_callable($this->config['attached_callback'])) {
+        if (!empty($this->config['attached_callback']) && is_callable($this->config['attached_callback'])) {
             $this->attached = $this->config['attached_callback']($id, $this->config);
         } else {
             $this->attached = $id;

--- a/framework/classes/attachment.php
+++ b/framework/classes/attachment.php
@@ -257,8 +257,8 @@ class Attachment
         $path = $this->path();
         $this->attached = $id;
 
-        if(!empty($config['attached_callback']) && is_callable($config['attached_callback'])) {
-            $this->attached = $config['attached_callback']($id);
+        if(!empty($this->config['attached_callback']) && is_callable($this->config['attached_callback'])) {
+            $this->attached = $this->config['attached_callback']($id, $this->config);
         } else {
             $this->attached = $id;
         }

--- a/framework/classes/attachment.php
+++ b/framework/classes/attachment.php
@@ -82,9 +82,8 @@ class Attachment
         }
         $config['alias'] = rtrim(str_replace(DS, '/', $config['alias']), '/').'/';
 
-        if(!empty($config['path_modifier']) && is_callable($config['path_modifier'])) {
-            $attached = $config['path_modifier']($attached, $config);
-            unset($config['path_modifier']);
+        if(!empty($config['attached_callback']) && is_callable($config['attached_callback'])) {
+            $attached = $config['attached_callback']($attached, $config);
         } else {
             $attached = preg_replace('`/`Uu', '_', $attached);
         }
@@ -257,6 +256,13 @@ class Attachment
     {
         $path = $this->path();
         $this->attached = $id;
+
+        if(!empty($config['attached_callback']) && is_callable($config['attached_callback'])) {
+            $this->attached = $config['attached_callback']($id);
+        } else {
+            $this->attached = $id;
+        }
+
         if ($path) {
             $this->set($path);
         }

--- a/framework/classes/attachment.php
+++ b/framework/classes/attachment.php
@@ -56,10 +56,10 @@ class Attachment
     public function __construct($attached, $config)
     {
         if (!is_array($config)) {
-            $config = \Config::load($config, true);
+            $config = \Config::load($config, false);
         }
 
-        $config = \Arr::merge(\Config::load('attachment', true), $config);
+        $config = \Arr::merge(\Config::load('attachment', false), $config);
 
         if (!empty($config['image']) && empty($config['extensions'])) {
             $config['extensions'] = $config['image_extensions'];
@@ -82,7 +82,13 @@ class Attachment
         }
         $config['alias'] = rtrim(str_replace(DS, '/', $config['alias']), '/').'/';
 
-        $attached = preg_replace('`/`Uu', '_', $attached);
+        if(!empty($config['path_modifier']) && is_callable($config['path_modifier'])) {
+            $attached = $config['path_modifier']($attached, $config);
+            unset($config['path_modifier']);
+        } else {
+            $attached = preg_replace('`/`Uu', '_', $attached);
+        }
+
         if (empty($attached)) {
             throw new \InvalidArgumentException('No attached ID specified.');
         }

--- a/framework/classes/attachment.php
+++ b/framework/classes/attachment.php
@@ -56,10 +56,10 @@ class Attachment
     public function __construct($attached, $config)
     {
         if (!is_array($config)) {
-            $config = \Config::load($config, false);
+            $config = \Config::load($config, true);
         }
 
-        $config = \Arr::merge(\Config::load('attachment', false), $config);
+        $config = \Arr::merge(\Config::load('attachment', true), $config);
 
         if (!empty($config['image']) && empty($config['extensions'])) {
             $config['extensions'] = $config['image_extensions'];

--- a/framework/classes/orm/attachment.php
+++ b/framework/classes/orm/attachment.php
@@ -46,7 +46,7 @@ class Orm_Attachment extends \Orm\Relation
         $this->cascade_delete  = array_key_exists('cascade_delete', $config)
             ? $config['cascade_delete'] : $this->cascade_delete;
 
-        $attachment_config = array_diff($config, array('key_from' => '', 'cascade_save' => '', 'cascade_delete' => ''));
+        $attachment_config = array_diff_assoc($config, array('key_from' => '', 'cascade_save' => '', 'cascade_delete' => ''));
         if (empty($attachment_config['dir'])) {
             $attachment_config['dir'] = strtolower(str_ireplace(array('\\', 'model_'), array(DS, ''), $from).DS.$name.DS);
         }

--- a/framework/classes/orm/attachment.php
+++ b/framework/classes/orm/attachment.php
@@ -46,7 +46,7 @@ class Orm_Attachment extends \Orm\Relation
         $this->cascade_delete  = array_key_exists('cascade_delete', $config)
             ? $config['cascade_delete'] : $this->cascade_delete;
 
-        $attachment_config = array_diff_assoc($config, array('key_from' => '', 'cascade_save' => '', 'cascade_delete' => ''));
+        $attachment_config = \Arr::filter_keys($config, array('key_from', 'cascade_save', 'cascade_delete'), true);
         if (empty($attachment_config['dir'])) {
             $attachment_config['dir'] = strtolower(str_ireplace(array('\\', 'model_'), array(DS, ''), $from).DS.$name.DS);
         }

--- a/htdocs/404.php
+++ b/htdocs/404.php
@@ -161,10 +161,13 @@ if ($is_attachment) {
     if ($match) {
         list(, $alias, $attached, $filename, $extension) = $m;
 
+        \Event::trigger_function('404.attachmentMatch', array(array('alias' => &$alias, 'attached' => &$attached, 'filename' => &$filename, 'extension' => &$extension)));
+
         $attachments = \Nos\Config_Data::get("attachments", array());
         if (isset($attachments[$alias])) {
             $config = $attachments[$alias];
             $attachment = \Nos\Attachment::forge($attached, $config);
+
             $send_file = $attachment->path();
             if (!empty($send_file)) {
                 if (isset($config['check']) && is_callable($config['check'])) {


### PR DESCRIPTION
This adds a callback allowing to customize the default storage strategy for attachments.

Example (model) :

``` php
public static function _init()
{
    static::$_attachment['file'] = array(
        'attached_callback' => function($id) {
            return 'foo/bar/'.$id;
        },
    );
}
```

To access the attachment, you also need to alter the alias in the new 404 event :

``` php
\Event::register_function('404.attachmentMatch', function($params) {
    $params['alias'] = dirname(dirname($params['alias'])).'/';
});
```
