### PR TITLE
Fix some french translations in MediaCentre

### DIFF
--- a/framework/applications/noviusos_media/lang/fr/common.lang.php
+++ b/framework/applications/noviusos_media/lang/fr/common.lang.php
@@ -205,7 +205,7 @@ return array(
 
     #: views/admin/media_edit.view.php:50
     #: views/admin/media_add.view.php:30
-    'The file size must not exceed {{size}}.' => 'La taille du fichier dépasse la limite {{size}}',
+    'The file size must not exceed {{size}}.' => 'La taille du fichier ne doit pas dépasser {{size}}o.',
 
     #: views/admin/media_edit.view.php:50
     #: views/admin/upload.view.php:83

--- a/framework/applications/noviusos_media/views/admin/media_add.view.php
+++ b/framework/applications/noviusos_media/views/admin/media_add.view.php
@@ -28,7 +28,7 @@ $fieldset->set_config('field_template', '{field}');
                 <tr>
                     <th></th>
                     <td>
-                        <p><em><?= strtr(__('The file size must not exceed {{size}}.'), array('{{size}}' => ini_get('upload_max_filesize'))) ?> <?= strtr(__('What’s more these file types are not allowed: {{extensions}}.'), array('{{extensions}}' => implode(', ', \Config::get('novius-os.upload.disabled_extensions', array('php'))))) ?></em></p>
+                        <p><em><?= strtr(__('The file size must not exceed {{size}}.'), array('{{size}}' => ini_get('upload_max_filesize'))) ?> <?= strtr(__('What’s more these file types are not allowed: {{extensions}}.'), array('{{extensions}}' => implode(', ', array_unique(\Config::get('novius-os.upload.disabled_extensions', array('php')))))) ?></em></p>
                     </td>
                 </tr>
                 <tr>

--- a/framework/applications/noviusos_media/views/admin/media_edit.view.php
+++ b/framework/applications/noviusos_media/views/admin/media_edit.view.php
@@ -47,7 +47,7 @@ if ($item->isImage()) {
                 <tr>
                     <th></th>
                     <td>
-                        <p><em><?= strtr(__('The file size must not exceed {{size}}.'), array('{{size}}' => ini_get('upload_max_filesize'), '.')) ?> <?= strtr(__('What’s more these file types are not allowed: {{extensions}}.'), array('{{extensions}}' => implode(', ', \Config::get('novius-os.upload.disabled_extensions', array('php'))))) ?></em></p>
+                        <p><em><?= strtr(__('The file size must not exceed {{size}}.'), array('{{size}}' => ini_get('upload_max_filesize'), '.')) ?> <?= strtr(__('What’s more these file types are not allowed: {{extensions}}.'), array('{{extensions}}' => implode(', ', array_unique(\Config::get('novius-os.upload.disabled_extensions', array('php')))))) ?></em></p>
                     </td>
                 </tr>
                 <tr>

--- a/framework/applications/noviusos_media/views/admin/upload.view.php
+++ b/framework/applications/noviusos_media/views/admin/upload.view.php
@@ -80,7 +80,7 @@ echo $fieldset->build_hidden_fields();
                 <tr>
                     <th></th>
                     <td>
-                        <p><em><?= strtr(__('Total files size must not exceed {{size}}.'), array('{{size}}' => ini_get('upload_max_filesize'))) ?> <?= strtr(__('What’s more these file types are not allowed: {{extensions}}.'), array('{{extensions}}' => implode(', ', \Config::get('novius-os.upload.disabled_extensions', array('php'))))) ?></em></p>
+                        <p><em><?= strtr(__('Total files size must not exceed {{size}}.'), array('{{size}}' => ini_get('upload_max_filesize'))) ?> <?= strtr(__('What’s more these file types are not allowed: {{extensions}}.'), array('{{extensions}}' => implode(', ', array_unique(\Config::get('novius-os.upload.disabled_extensions', array('php')))))) ?></em></p>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
- French translation wasn't... french :)
- Sometimes, due to config recursive merge, we have extensions duplicate.
