### PR TITLE
Bugfixing pages not working when a root page (or home) has an enhancer

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -183,15 +183,16 @@ class Controller_Front extends Controller
                 return $result;
             });
 
+            // Add current url to URLs enhanced
+            $url_enhanced['current'] = array(
+                'url'   => $url.'/',
+                'depth' => mb_substr_count($url.'/', '/'),
+            );
+
             // Sorting the array to check the deepest urls at first
             uasort($url_enhanced, function($a, $b) {
                 return $b['depth'] - $a['depth'];
             });
-
-            // Add current url to URLs enhanced
-            $url_enhanced['current'] = array(
-                'url' => $url.'/',
-            );
 
             $_404 = true;
             // Loop URLs enhanced for one that not send a NotFoundException

--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -173,12 +173,19 @@ class Controller_Front extends Controller
             // Filter URLs enhanced : remove if not in possibles contexts, remove if url not match
             $url_enhanced = \Nos\Config_Data::get('url_enhanced', array());
             $base_href = $this->_base_href;
-            $url_enhanced = array_filter($url_enhanced, function ($page_params) use ($contexts_possibles, $base_href, $url) {
+            $url_enhanced = array_filter($url_enhanced, function (&$page_params) use ($contexts_possibles, $base_href, $url) {
                 if (!in_array($page_params['context'], array_keys($contexts_possibles))) {
                     return false;
                 }
                 $url_absolute = $contexts_possibles[$page_params['context']].$page_params['url'];
-                return mb_substr($base_href.$url.'/', 0, mb_strlen($url_absolute)) === $url_absolute;
+                $result = mb_substr($base_href.$url.'/', 0, mb_strlen($url_absolute)) === $url_absolute;
+                $page_params['depth'] = mb_substr_count($page_params['url'], '/');
+                return $result;
+            });
+
+            // Sorting the array to check the deepest urls at first
+            uasort($url_enhanced, function($a, $b) {
+                return $b['depth'] - $a['depth'];
             });
 
             // Add current url to URLs enhanced

--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -188,11 +188,13 @@ class Controller_Front extends Controller
                 'url'   => $url.'/',
                 'depth' => mb_substr_count($url.'/', '/'),
             );
-
-            // Sorting the array to check the deepest urls at first
-            uasort($url_enhanced, function($a, $b) {
-                return $b['depth'] - $a['depth'];
-            });
+            
+            if (\Config::get('novius-os.enable_url_enhancers_on_root_pages', false)) {
+                // Sorting the array to check the deepest urls at first
+                uasort($url_enhanced, function($a, $b) {
+                    return $b['depth'] - $a['depth'];
+                });
+            }
 
             $_404 = true;
             // Loop URLs enhanced for one that not send a NotFoundException

--- a/framework/config/config.php
+++ b/framework/config/config.php
@@ -285,6 +285,8 @@ return array(
         'assets_minified' => Fuel::$env !== Fuel::DEVELOPMENT,
 
         'migration_config_file' => false,
+        
+        'enable_url_enhancers_on_root_pages' => true,
 
         'finder_paths' => array(
             APPPATH,


### PR DESCRIPTION
Having an enhancer in a page which is a parent of another page with enhancer can 'randomly' cause the child url to show the parent page instead.

This bug doesn't always appears because it depends on the order of items in the `local/data/config/url_enhanced.php` file:

``` php
<?php
return array (
  1 => 
  array (
    'url' => 'bar/',
    'context' => 'main::fr_FR',
  ),
  2 => 
  array (
    'url' => '',
    'context' => 'main::fr_FR',
  ),
);
```
# How to reproduce it?
1. Create two different pages `foo` and `bar` with an enhancer into each one ;
2. Make `foo` the home page;
3. Edit and save `bar` (without necessarily changing something). This will move it as the last element in `local/data/config/url_enhanced.php`;
4. Try to show `bar` (front). The url will return `foo` instead;
5. Now if you edit and save `foo` (without necessarily changing something), it will move as the last element in the config file, and `bar` will work again.
# Why?

This is caused by the filter at line 181: 

``` php
return mb_substr($base_href.$url.'/', 0, mb_strlen($url_absolute)) === $url_absolute;
```

which is always true for parent pages.
In our example, two items will pass the test when the page is requested:
- `bar`, because `substr('http://example.com/bar/', strlen('http://example.com/bar/')) === 'http://example.com/bar/'` is true
- `foo` (or root) because `substr('http://example.com/bar/', strlen('http://example.com/')) === 'http://example.com/'` is true

Only the first element in the array will be shown.
# My fix

Since it would be overcomplicated to directly change the filter, my fix sorts the filtered array, with the "deepest" page in the hierarchy at first.
Since the current behaviour is 'random', this just enforces the consistency and shouldn't break retro-compatibility.
