### PR TITLE
Disable button during submit

### DIFF
--- a/static/admin/novius-os/js/jquery.novius-os.js
+++ b/static/admin/novius-os/js/jquery.novius-os.js
@@ -1169,18 +1169,31 @@ define('jquery-nos',
 
             nosFormAjax : function() {
                 var $context = this;
+                var $btn;
 
                 if (!$context.is('form')) {
                     $context = $context.find('form');
                 }
                 require(['jquery-form'], function() {
                     $context.ajaxForm({
+                        beforeSubmit: function(arr, $form, options) {
+                            $btn = $(document.activeElement);
+                            if ($context.prop('disabled')) {
+                                return false;
+                            }
+                            $btn.prop('disabled', true).addClass('ui-state-disabled');
+                            $context.prop('disabled', true);
+                        },
                         dataType: 'json',
                         success: function(json) {
+                            $context.prop('disabled', false);
+                            $btn.prop('disabled', false).removeClass('ui-state-disabled');
                             $context.nosAjaxSuccess(json)
                                 .triggerHandler('ajax_success', [json]);
                         },
                         error: function(x, e) {
+                            $context.prop('disabled', false);
+                            $btn.prop('disabled', false).removeClass('ui-state-disabled');
                             $context.nosAjaxError(x, e);
                         }
                     });


### PR DESCRIPTION
There is a little UX incoherence in the way Novius OS handle ajax form, you can submit it again and again before waiting for the action to proceed. In some cases it can lead to problems when you mash the buttons waiting for a response without visual clues.

With this PR i've added a disabled status to the form submitting, waiting for the request to end (successfully or not) before allowing an other submission. I've also added a disabled style to the submit button to have a more visual representation of the request processing. The style will go off either when the action is succesful, or at any nosAjaxError (since we can't properly target the button otherwise).

~~I've added an event in the NosAjaxError method, being thrown everytime an error occur (loss of connection, or dead server for example).~~

I've changed the implementation by only modifying the behaviour of nosFormAjax, disabled and adding a visual clue any sort of triggering element.
