### PR TITLE
Make items callable in fieldset validation

### DIFF
--- a/framework/classes/fuel/fieldset.php
+++ b/framework/classes/fuel/fieldset.php
@@ -451,6 +451,7 @@ class Fieldset extends \Fuel\Core\Fieldset
 
         if ($options['save'] && (empty($options['form_name']) || \Input::post('form_name') == $options['form_name'])) {
             $fieldset->repopulate();
+            $fieldset->validation()->add_callable($item);
             if ($fieldset->validation()->run($fieldset->value())) {
                 $json = $fieldset->triggerComplete($item, $fieldset->validated(), $options);
                 \Response::json($json);


### PR DESCRIPTION
Allow to add custom validations to crud config. These custom validations can be defined on the item model with prefix "_validation_".
