### PR TITLE
Fixing wysiwyg to show enhancers everywhere

### DIFF
--- a/framework/classes/tools/wysiwyg.php
+++ b/framework/classes/tools/wysiwyg.php
@@ -216,31 +216,33 @@ class Tools_Wysiwyg
                 'model' => $model,
                 'id' => $item->{$pk},
             );
-
-            $enhancers = Config_Data::get('enhancers', array());
-
-            if (!$urlEnhancers) {
-                $enhancers = array_filter($enhancers, function ($enhancer) {
-                    return empty($enhancer['urlEnhancer']);
-                });
-            }
-
-            foreach ($enhancers as $key => $enhancer) {
-                if (empty($enhancer['iconUrl']) && !empty($enhancer['application'])) {
-                    $enhancers[$key]['iconUrl'] = \Config::icon($enhancer['application'], 16);
-                }
-                if (!empty($enhancer['valid_container']) && is_callable($enhancer['valid_container']) &&
-                    call_user_func($enhancer['valid_container'], $enhancer, $item) === false) {
-
-                    unset($enhancers[$key]);
-                }
-            }
-
-            $options['nosenhancer_enhancers'] = $enhancers;
-
-            $item->event('wysiwygOptions', array(&$options));
         }
 
+        $enhancers = Config_Data::get('enhancers', array());
+
+        if (!$urlEnhancers) {
+            $enhancers = array_filter($enhancers, function ($enhancer) {
+                return empty($enhancer['urlEnhancer']);
+            });
+        }
+
+        foreach ($enhancers as $key => $enhancer) {
+            if (empty($enhancer['iconUrl']) && !empty($enhancer['application'])) {
+                $enhancers[$key]['iconUrl'] = \Config::icon($enhancer['application'], 16);
+            }
+            if (!empty($enhancer['valid_container']) && is_callable($enhancer['valid_container']) &&
+                call_user_func($enhancer['valid_container'], $enhancer, $item) === false) {
+
+                unset($enhancers[$key]);
+            }
+        }
+
+        $options['nosenhancer_enhancers'] = $enhancers;
+
+        if(!empty($item)) {
+            $item->event('wysiwygOptions', array(&$options));
+        }
+        
         return $options;
     }
 }

--- a/framework/classes/tools/wysiwyg.php
+++ b/framework/classes/tools/wysiwyg.php
@@ -239,7 +239,7 @@ class Tools_Wysiwyg
 
         $options['nosenhancer_enhancers'] = $enhancers;
 
-        if(!empty($item)) {
+        if (!empty($item)) {
             $item->event('wysiwygOptions', array(&$options));
         }
         


### PR DESCRIPTION
This fixes the WYSIWYG from showing an empty "Applications" menu (= enhancers) when it's rendered from a form which is not referring to a specific Model (for example in lib_options or inside another Enhancer's pop-up).
