### PR TITLE
Bugfix with turkish characters in cache suffix Handler

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -194,7 +194,7 @@ class FrontCache
                         $keys = (array) $handler['keys'];
                         foreach ($keys as $key) {
                             if (isset($_GET[$key])) {
-                                $suffixes[] = 'GET['.urlencode($key).']='.(is_array($_GET[$key]) ? http_build_query($_GET[$key]) : urlencode($_GET[$key]));
+                                $suffixes[] = 'GET['.urlencode($key).']='.(ctype_alnum($_GET[$key]) ? urlencode($_GET[$key]) : 'md5-'.md5($_GET[$key]));
                             }
                         }
                     }

--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -194,7 +194,8 @@ class FrontCache
                         $keys = (array) $handler['keys'];
                         foreach ($keys as $key) {
                             if (isset($_GET[$key])) {
-                                $suffixes[] = 'GET['.urlencode($key).']='.(ctype_alnum($_GET[$key]) ? urlencode($_GET[$key]) : 'md5-'.md5($_GET[$key]));
+                                $value = (is_array($_GET[$key]) ? http_build_query($_GET[$key]) : urlencode($_GET[$key]));
+                                $suffixes[] = 'GET['.urlencode($key).']='.(ctype_alnum($value) ? $value : 'md5-'.md5($value));
                             }
                         }
                     }


### PR DESCRIPTION
We have an issue with the cache "GET suffix handler" with turkish characters, resulting in incorrect file name on some systems.
