### PR TITLE
Clean fuel cache on migrations

### DIFF
--- a/framework/classes/migration.php
+++ b/framework/classes/migration.php
@@ -26,6 +26,7 @@ class Migration
     {
         if (file_exists($this->sql_file)) {
             static::executeSqlFile($this->sql_file);
+            $this->clearFuelCache();
         }
     }
 
@@ -45,6 +46,10 @@ class Migration
                 \DB::query($query)->execute();
             }
         }
+    }
+
+    protected function clearFuelCache()
+    {
         $fuelCachePath = NOSROOT.'public/cache/fuelphp';
         if (file_exists($fuelCachePath)) {
             \File::delete_dir($fuelCachePath, true, false);

--- a/framework/classes/migration.php
+++ b/framework/classes/migration.php
@@ -45,6 +45,10 @@ class Migration
                 \DB::query($query)->execute();
             }
         }
+        $fuelCachePath = NOSROOT.'public/cache/fuelphp';
+        if (file_exists($fuelCachePath)) {
+            \File::delete_dir($fuelCachePath, true, false);
+        }
     }
 
     public function down()


### PR DESCRIPTION
If there is a migration with an alteration of the database, it makes sense to empty the fuel cache as properties that were once there may be removed or new one can appear and won't be caught by the cache.
