### PR TITLE
Force download file if mime type is text/plain

### DIFF
--- a/framework/classes/tools/file.php
+++ b/framework/classes/tools/file.php
@@ -143,7 +143,7 @@ class Tools_File
             } else {
                 $info = \File::file_info($file);
                 empty($mime) or $info['mimetype'] = $mime;
-                if ($info['mimetype'] == 'text/plain') {
+                if ($info['mimetype'] === 'text/plain') {
                     $info['mimetype'] = 'application/force-download';
                 }
 

--- a/framework/classes/tools/file.php
+++ b/framework/classes/tools/file.php
@@ -143,9 +143,6 @@ class Tools_File
             } else {
                 $info = \File::file_info($file);
                 empty($mime) or $info['mimetype'] = $mime;
-                if ($info['mimetype'] === 'text/plain') {
-                    $info['mimetype'] = 'application/force-download';
-                }
 
                 \Event::register('fuel-shutdown', function () use ($info) {
 
@@ -156,6 +153,7 @@ class Tools_File
                     ini_get('zlib.output_compression') and ini_set('zlib.output_compression', 0);
                     ! ini_get('safe_mode') and set_time_limit(0);
 
+                    header('Content-Disposition: attachment; filename='.urlencode(\Arr::get($info, 'basename', '')));
                     header('Content-Type: '.$info['mimetype']);
                     header('Content-Length: '.$info['size']);
                     header('Content-Transfer-Encoding: binary');

--- a/framework/classes/tools/file.php
+++ b/framework/classes/tools/file.php
@@ -143,6 +143,9 @@ class Tools_File
             } else {
                 $info = \File::file_info($file);
                 empty($mime) or $info['mimetype'] = $mime;
+                if ($info['mimetype'] == 'text/plain') {
+                    $info['mimetype'] = 'application/force-download';
+                }
 
                 \Event::register('fuel-shutdown', function () use ($info) {
 


### PR DESCRIPTION
Prevent browser to display file content by replacing "text/plain" mime type by "application/force-download"
