### PR TITLE
Uninstalling dependencies instead of crashing

### DIFF
--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -443,11 +443,10 @@ class Application
     {
         if (!$this->canUninstall()) {
             $dependents = $this->installedDependentApplications();
-            throw new \Exception(
-                'Application '.$this->folder.
-                ' can\'t be uninstalled because it is required by the following applications: '.
-                implode(', ', $dependents).'.'
-            );
+            foreach($dependents as $dependent_name) {
+                $dependent = static::forge($dependent_name);
+                $dependent->uninstall();
+            }
         }
         $old_metadata = \Arr::get(static::$rawAppInstalled, $this->folder);
         $new_metadata = array();


### PR DESCRIPTION
This allows novius-os to handle the case when an application which is a dependency of another has been removed directly from drive without being uninstalled first. This allows novius-os to properly uninstall the dependent apps instead of just crashing without any other way to recover else than manually editing the data file.
