### PR TITLE
Update "page_menu_title" property when cloning page

### DIFF
--- a/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
+++ b/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
@@ -312,6 +312,7 @@ class Controller_Admin_Page extends \Nos\Controller_Admin_Crud
                         '{{count}}' => $try,
                     ));
                     $clone->page_title = $main->page_title.$title_append;
+                    $clone->page_menu_title = $clone->page_title;
                     $clone->page_virtual_name = null;
                     $clone->page_virtual_url = null;
                 }


### PR DESCRIPTION
Update clone's "page_menu_title" property when cloning page so it can reflect the new name of the page.
Currently, it keep the same value as the inital page, wich is breaking the menu's "Use page title" functionnality.
