### PR TITLE
Fix setOrCreateRelation

### DIFF
--- a/framework/classes/fuel/orm/model.php
+++ b/framework/classes/fuel/orm/model.php
@@ -864,16 +864,16 @@ class Model extends \Orm\Model
             $rel = $obj->relations($val_name);
             if (!empty($rel)) {
                 $obj = &$obj->get($val_name);
-                if (empty($obj)) {
-                    $model_to = $rel->model_to;
-                    $related = $model_to::forge();
+                $model_to = $rel->model_to;
+                $related = $model_to::forge();
+                if (!empty($obj)) {
                     if ($rel->singular) {
                         $obj->{$val_name} = $related;
                     } else {
                         $obj->{$val_name}[] = $related;
                     }
-                    $obj = $related;
                 }
+                $obj = $related;
             } else if (array_key_exists($val_name, $obj::properties())) {
                 $obj->set($val_name, $value);
             }


### PR DESCRIPTION
I'm not sure wether or not this may be a breaking change (in that case it's for a future version), but this part of the code is wrong and can never succeed. It causes crashes in some cases for example when trying to save a sub-field from a has-one relation in a crud.

The line `$obj->{$val_name}` can't succeed because it's inside an `if (empty($obj))`.
