### PR TITLE
Reload application config all the time

### DIFF
--- a/framework/classes/fuel/config.php
+++ b/framework/classes/fuel/config.php
@@ -134,7 +134,7 @@ class Config extends \Fuel\Core\Config
 
     public static function application($application_name)
     {
-        return static::load($application_name.'::config', true);
+        return static::load($application_name.'::config', false, true);
     }
 
     public static function actions($params = array())


### PR DESCRIPTION
For some reason due to Fuel's magic with the config file, the \Config::application can't be load. Since it's mandatory for every controller to work there is not much else we can do...
