### PR TITLE
New method getContextCommonId() + Renamed/deprecated methods

### DIFF
--- a/framework/classes/orm/behaviour/contextable.php
+++ b/framework/classes/orm/behaviour/contextable.php
@@ -43,14 +43,29 @@ class Orm_Behaviour_Contextable extends Orm_Behaviour
     }
 
     /**
-     * Returns the locale of the current object
+     * @deprecated Please consider using getContext() instead.
      *
      * @param \Nos\Orm\Model $item
      * @return string
      */
     public function get_context(Orm\Model $item)
     {
-        return $item->get($this->_properties['context_property']);
+        return return $this->getContext($item);
+    }
+
+    /**
+     * Returns the context of the current object
+     *
+     * @param \Nos\Orm\Model $item
+     * @return string|null
+     */
+    public function getContext(Orm\Model $item)
+    {
+        if (!empty($this->_properties['context_property'])) {
+            return $item->get($this->_properties['context_property']);
+        } else {
+            return null;
+        }
     }
 
     public function form_fieldset_fields(Orm\Model $item, &$fieldset)

--- a/framework/classes/orm/behaviour/contextable.php
+++ b/framework/classes/orm/behaviour/contextable.php
@@ -50,7 +50,7 @@ class Orm_Behaviour_Contextable extends Orm_Behaviour
      */
     public function get_context(Orm\Model $item)
     {
-        return return $this->getContext($item);
+        return $this->getContext($item);
     }
 
     /**

--- a/framework/classes/orm/behaviour/twinnable.php
+++ b/framework/classes/orm/behaviour/twinnable.php
@@ -348,14 +348,14 @@ class Orm_Behaviour_Twinnable extends Orm_Behaviour_Contextable
     }
 
     /**
-     * @deprecated Please consider using isContextMain() instead.
+     * @deprecated Please consider using isMainContext() instead.
      *
      * @param \Nos\Orm\Model $item
      * @return bool
      */
     public function is_main_context(Orm\Model $item)
     {
-        return $this->isContextMain($item);
+        return $this->isMainContext($item);
     }
 
     /**
@@ -364,7 +364,7 @@ class Orm_Behaviour_Twinnable extends Orm_Behaviour_Contextable
      * @param \Nos\Orm\Model $item
      * @return bool|null
      */
-    public function isContextMain(Orm\Model $item)
+    public function isMainContext(Orm\Model $item)
     {
         if (!empty($this->_properties['is_main_property'])) {
             return (bool) $item->get($this->_properties['is_main_property']);

--- a/framework/classes/orm/behaviour/twinnable.php
+++ b/framework/classes/orm/behaviour/twinnable.php
@@ -348,15 +348,44 @@ class Orm_Behaviour_Twinnable extends Orm_Behaviour_Contextable
     }
 
     /**
-     * Returns null if the Model is not twinnable. Returns true or false whether the object is in the main context.
+     * @deprecated Please consider using isContextMain() instead.
      *
      * @param \Nos\Orm\Model $item
      * @return bool
      */
     public function is_main_context(Orm\Model $item)
     {
-        // use !! for cast to boolean
-        return !!$item->get($this->_properties['is_main_property']);
+        return $this->isContextMain($item);
+    }
+
+    /**
+     * Returns true or false whether the object is in the main context.
+     *
+     * @param \Nos\Orm\Model $item
+     * @return bool|null
+     */
+    public function isContextMain(Orm\Model $item)
+    {
+        if (!empty($this->_properties['is_main_property'])) {
+            return (bool) $item->get($this->_properties['is_main_property']);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the locale of the current object
+     *
+     * @param \Nos\Orm\Model $item
+     * @return mixed|null
+     */
+    public function getContextCommonId(Orm\Model $item)
+    {
+        if (!empty($this->_properties['common_id_property'])) {
+            return $item->get($this->_properties['common_id_property']);
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Adds a new shorthand method `getContextCommonId()` to get the common ID of an item.

Methods `get_context()` and `is_main_context()` are now deprecated (PHPDoc only until the next major release) and respectively replaced by `getContext()` and `isMainContext()`.
