### PR TITLE
Adding a setting to allow urls to unpublished items

### DIFF
--- a/framework/classes/tools/enhancer.php
+++ b/framework/classes/tools/enhancer.php
@@ -111,7 +111,7 @@ class Tools_Enhancer
             }
             if (!$preview) {
                 $published = $item::behaviours('Nos\Orm_Behaviour_Publishable');
-                if (!empty($published) && !$item->published()) {
+                if (!empty($published) && !$item->published() && !\Arr::get($published, 'allow_urls_to_unpublished_items', false)) {
                     return array();
                 }
             }


### PR DESCRIPTION
This adds a configuration key `allow_urls_to_unpublished_items` in `Nos\Orm_Behaviour_Publishable` to allow urls to be generated to unpublished items.

This can be useful in some cases where a front-office user must have access to some data that has been unpublished from back-office and thus is not visible in front for anybody else.

This also allows to avoid inconsistencies since the default filter is only implemented when generating urls and not at all when listing items from front-office.
