### PR TITLE
Enforce 16px width for icons on the appmanager

### DIFF
--- a/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
+++ b/framework/applications/noviusos_appmanager/views/admin/app_manager.view.php
@@ -63,7 +63,7 @@ foreach ($installed as $app) {
     $metadata = $app->metadata;
     ?>
                     <tr>
-                        <td>&nbsp;<img src="<?= isset($metadata['icons'][16]) ? $metadata['icons'][16] : 'static/novius-os/admin/novius-os/img/16/application.png' ?>" style="vertical-align:top;" alt="" title="" /> <?= e(Nos\Config_Data::get('app_installed.'.$app->folder.'.name', $app->name)); ?></td>
+                        <td>&nbsp;<img src="<?= isset($metadata['icons'][16]) ? $metadata['icons'][16] : 'static/novius-os/admin/novius-os/img/16/application.png' ?>" width="16" style="vertical-align:top;" alt="" title="" /> <?= e(Nos\Config_Data::get('app_installed.'.$app->folder.'.name', $app->name)); ?></td>
                         <td>
     <?php
     if ($app->is_dirty()) {


### PR DESCRIPTION
For example you could configure "poor man's icons" like so

``` php
<?php
return array(
    'icons' => array(
        64 => 'static/apps/api/img/api.svg',
        32 => 'static/apps/api/img/api.svg',
        16 => 'static/apps/api/img/api.svg',
    ),
);
```

``` svg
<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
    <text fill="#000000" x="50%" y="50%" dy=".3em" font-family="Verdana" font-size="12" text-anchor="middle">
        API
    </text>
</svg>
```

But the 64px viewbox would not be sized down to 16px
