### PR TITLE
Remove focus forced on email input in admin login page

### DIFF
--- a/framework/views/admin/login.view.php
+++ b/framework/views/admin/login.view.php
@@ -27,14 +27,13 @@ if (!empty($error)) {
     <?php
 }
 ?>
-            $('#email').select();
         });
     });
 </script>
 <div id="login">
     <img src="static/novius-os/admin/novius-os/img/logo.png" alt="" />
     <form method="POST" action="">
-        <p><input type="email" name="email" id="email" value="<?= e(\Input::post('email', '')); ?>" placeholder="<?= __('Email address') ?>" /></p>
+        <p><input type="email" name="email" id="email" value="<?= e(\Input::post('email', '')); ?>" placeholder="<?= __('Email address') ?>" autofocus /></p>
         <p><input type="password" name="password" placeholder="<?= __('Password') ?>" /></p>
         <p>
             <input type="checkbox" id="remember_me" name="remember_me" value="1" />


### PR DESCRIPTION
This removes an annoying focus forced on the email field.

When you have a slow connection to the server, you can start typing your login and password while some assets are still loading. The loading often ends up while you're typing the password, which is annoying because it unexpectedly changes the focus on the email, and then replaces it with a part of your password clearly readable...