### PR TITLE
Replaces the twinnable property force_context with force_context_fallback

### DIFF
--- a/framework/classes/orm/twinnable/belongsto.php
+++ b/framework/classes/orm/twinnable/belongsto.php
@@ -111,12 +111,12 @@ class Orm_Twinnable_BelongsTo extends \Orm\BelongsTo
         if ($this->front_context_fallback && (NOS_ENTRY_POINT == Nos::ENTRY_POINT_FRONT)) {
             //front context is used
             $context_to = Nos::main_controller()->getContext();
-        } elseif (empty($this->force_context_fallback)) {
+        } elseif (!empty($this->force_context_fallback)) {
+            //specified context is used
+            $context_to = $this->force_context_fallback;
+        } else {
             //model context is used
             $context_to = $from->{$this->column_context_from};
-        } else {
-            //default context is used
-            $context_to = $this->force_context_fallback;
         }
         $context_to = \DB::expr(\DB::quote($context_to));
 
@@ -186,12 +186,12 @@ class Orm_Twinnable_BelongsTo extends \Orm\BelongsTo
         if ($this->front_context_fallback && (NOS_ENTRY_POINT == Nos::ENTRY_POINT_FRONT)) {
             //front context is used
             $context_to = \DB::expr(\DB::quote(Nos::main_controller()->getContext()));
-        } elseif (empty($this->force_context_fallback)) {
+        } elseif (!empty($this->force_context_fallback)) {
+            //specified context is used
+            $context_to = \DB::expr(\DB::quote($this->force_context_fallback));
+        } else {
             //model context is used
             $context_to = $alias_from.'.'.$this->column_context_from;
-        } else {
-            //default context is used
-            $context_to = \DB::expr(\DB::quote($this->force_context));
         }
 
 

--- a/framework/classes/orm/twinnable/hasmany.php
+++ b/framework/classes/orm/twinnable/hasmany.php
@@ -110,12 +110,12 @@ class Orm_Twinnable_HasMany extends \Orm\HasMany
         if ($this->front_context_fallback && (NOS_ENTRY_POINT == Nos::ENTRY_POINT_FRONT)) {
             //front context is used
             $context_to = Nos::main_controller()->getContext();
-        } elseif (empty($this->force_context_fallback)) {
+        } elseif (!empty($this->force_context_fallback)) {
+            //specified context is used
+            $context_to = $this->force_context_fallback;
+        } else {
             //model context is used
             $context_to = $from->{$this->column_context_from};
-        } else {
-            //default context is used
-            $context_to = $this->force_context_fallback;
         }
 
         return $class::findMainOrContext($context_to, $conditions);
@@ -182,12 +182,12 @@ class Orm_Twinnable_HasMany extends \Orm\HasMany
         if ($this->front_context_fallback && (NOS_ENTRY_POINT == Nos::ENTRY_POINT_FRONT)) {
             //front context is used
             $context_to = \DB::expr(\DB::quote(Nos::main_controller()->getContext()));
-        } elseif (empty($this->force_context_fallback)) {
+        } elseif (!empty($this->force_context_fallback)) {
+            //specified context is used
+            $context_to = \DB::expr(\DB::quote($this->force_context_fallback));
+        } else {
             //model context is used
             $context_to = $alias_from.'.'.$this->column_context_from;
-        } else {
-            //default context is used
-            $context_to = \DB::expr(\DB::quote($this->force_context));
         }
 
         $models[$rel_name_main]['join_on'][] = array($alias_to_main.'.'.$this->column_context_is_main_to, '=', DB::expr(1));

--- a/framework/classes/orm/twinnable/hasone.php
+++ b/framework/classes/orm/twinnable/hasone.php
@@ -104,12 +104,12 @@ class Orm_Twinnable_HasOne extends \Orm\HasOne
         if ($this->front_context_fallback && (NOS_ENTRY_POINT == Nos::ENTRY_POINT_FRONT)) {
             //front context is used
             $context_to = Nos::main_controller()->getContext();
-        } elseif (empty($this->force_context_fallback)) {
+        } elseif (!empty($this->force_context_fallback)) {
+            //specified context is used
+            $context_to = $this->force_context_fallback;
+        } else {
             //model context is used
             $context_to = $from->{$this->column_context_from};
-        } else {
-            //default context is used
-            $context_to = $this->force_context_fallback;
         }
 
         $query->and_where_open();
@@ -187,12 +187,12 @@ class Orm_Twinnable_HasOne extends \Orm\HasOne
         if ($this->front_context_fallback && (NOS_ENTRY_POINT == Nos::ENTRY_POINT_FRONT)) {
             //front context is used
             $context_to = \DB::expr(\DB::quote(Nos::main_controller()->getContext()));
-        } elseif (empty($this->force_context_fallback)) {
+        } elseif (!empty($this->force_context_fallback)) {
+            //specified context is used
+            $context_to = \DB::expr(\DB::quote($this->force_context_fallback));
+        } else {
             //model context is used
             $context_to = $alias_from.'.'.$this->column_context_from;
-        } else {
-            //default context is used
-            $context_to = \DB::expr(\DB::quote($this->force_context));
         }
 
 


### PR DESCRIPTION
The `force_context` property doesn't exists on any twinnable relation and is partially/badly implemented which throws an exception in some cases.

I didn't found any usages nor documentations since the first release of Novius OS (`0.2`) so this seems to be a ghost property...