### PR TITLE
Attempt to fix the concurrent media generation bug

### DIFF
--- a/framework/config/cache.config.php
+++ b/framework/config/cache.config.php
@@ -13,4 +13,18 @@ return array(
     'file'  => array(
         'path'  =>    APPPATH.'cache/fuelphp/',
     ),
+    'media' => array(
+        // Configuration relative to the concurrent access
+        // checks wheile generating a media cache
+        'generation' => array(
+            // Maximum time to generate a media before the process
+            // is considered as failed and another is allowed
+            // to try to generate the media.
+            'timeout'     => '+45 seconds',
+
+            // Redirect every x (int) seconds if the media is requested
+            // while another process is already generating it.
+            'retry_delay' => 2,
+        ),
+    ),
 );


### PR DESCRIPTION
This is an attempt to solve the "random" media generation bug.

The previous code used a `file_put_contents` as a shorthand for locking and writing the lock file. But since file_put_contents also makes a `fclose` (which releases the lock), the generation code wasn't properly protected.