### PR TITLE
Fix parse on croped and resized images

### DIFF
--- a/framework/classes/toolkit/image.php
+++ b/framework/classes/toolkit/image.php
@@ -444,7 +444,7 @@ class Toolkit_Image
         }
 
         // Check if hash part matched and if all transformations exist
-        if ($this->url(false) !== $image_url) {
+        if ($this->url(false) !== $image_url && $this->url(false) !== Tools_Url::encodePath($pathinfo['dirname'], false).DS.$pathinfo['basename']) {
             return false;
         }
         return true;


### PR DESCRIPTION
Since #270, parse() fails with some images (with encoded characters).

For instance, with an image named "soirée salon-de-compagnie", `$media->urlResized(400, 200)` returns something like this:
```
cache/media/soir%C3%A9e%20salon-de-compagnie/s,400,200-7b1ee4.jpg
```

Then, Novius OS calls `$toolkit_image->parse($image_url)`. `$image_url` contains this:

```
cache/media/soirée salon-de-compagnie/s,400,200-7b1ee4.jpg
```

So... `$image_url` differs from `$media->url(false)`. In this case, we have to encode image dirname, like `$media-urlResized()` does.


FYI, with this example, `pathinfo($image_url)` returns this:
```
Array
(
    [dirname] => cache/media/soirée salon-de-compagnie
    [basename] => s,400,200-7b1ee4.jpg
    [extension] => jpg
    [filename] => s,400,200-7b1ee4
)
```