### PR TITLE
Allows searching a page by it's URL

### DIFF
--- a/framework/applications/noviusos_page/config/controller/admin/appdesk.config.php
+++ b/framework/applications/noviusos_page/config/controller/admin/appdesk.config.php
@@ -12,7 +12,10 @@ Nos\I18n::current_dictionary(array('noviusos_page::common', 'nos::common'));
 
 return array(
     'model' => 'Nos\Page\Model_Page',
-    'search_text' => 'page_title',
+    'search_text' => array(
+        'page_title',
+        'page_virtual_url',
+    ),
     'selectedView' => 'default',
     'views' => array(
         'default' => array(


### PR DESCRIPTION
The public page title and url (virtual name) can both be different that the title visible in the back office.

Sometimes it's then hard to find the appropriate page in back office when you just got it's public url.

This allows to search a page by it's url (it even works with or without the `.html` and with or without the parent "directories").