### PR TITLE
[Dubrovka] Fix `<script language>` and `<?xml` regex filters

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -279,9 +279,9 @@ class FrontCache
         }
 
         // Prevent PHP injection using a <script language=php> tag
-        $this->_content = preg_replace('`<script\s+language=(.?)php\1\s*>(.*?)</script>`i', '&lt;script language=$1php$1>$2&lt;/script>', $this->_content);
-        $this->_content = preg_replace('`<\?(?!xml)`i', '&lt;?', $this->_content);
-        $this->_content = str_replace('<?xml', "<?= '<?' ?>xml", $this->_content);
+        $this->_content = preg_replace('/<script\s+language\s*=\s*(php|"php"|\'php\')\s*>/i', '&lt;script language=$1>', $this->_content);
+        $this->_content = preg_replace('/<\?(?!xml)/i', '&lt;?', $this->_content);
+        $this->_content = preg_replace('/<\?xml/i', "<?= '<?' ?>xml", $this->_content);
 
         if (null !== static::$_php_begin) {
             $this->_content = strtr(


### PR DESCRIPTION
- str_replace is replaced with case-insensitive regex to match every xml opening
- Looking for the closing </script> cannot match everything, so we now look for
the opening tag only.
  The regex is also updated to use the same as php's zend_language_scanner.

Thanks to @Kcazer for spotting these