### PR TITLE
Refactored the renderer/publishable view to make it extendable

### DIFF
--- a/framework/classes/renderer/publishable.php
+++ b/framework/classes/renderer/publishable.php
@@ -15,6 +15,30 @@ class Renderer_Publishable extends Renderer
     protected static $DEFAULT_RENDERER_OPTIONS = array(
         'item' => null,
         'view' => 'nos::renderer/publishable',
+        'populate' => null, // Callback allowing the selected value to be changed
+        'radio_options' => array(
+            'no' => array(
+                'value'      => '0',
+                'content'    => '<img src="static/novius-os/admin/novius-os/img/icons/status-red.png" />',
+                'attributes' => array(
+                    'class' => 'notransform',
+                ),
+            ),
+            'planned' => array(
+                'value'      => '2',
+                'content'    => '<span class="ui-icon ui-icon-clock" />',
+                'attributes' => array(
+                    'class' => 'notransform',
+                ),
+            ),
+            'yes' => array(
+                'value'      => '1',
+                'content'    => '<img src="static/novius-os/admin/novius-os/img/icons/status-green.png" />',
+                'attributes' => array(
+                    'class' => 'notransform',
+                ),
+            ),
+        ),
     );
 
     /**

--- a/framework/classes/renderer/publishable.php
+++ b/framework/classes/renderer/publishable.php
@@ -48,68 +48,9 @@ class Renderer_Publishable extends Renderer
      */
     public function build()
     {
-        $options = &$this->renderer_options;
-
-        if (empty($options['item'])) {
-            $options['item'] = $this->fieldset()->getInstance();
+        if (empty($this->renderer_options['item'])) {
+            $this->renderer_options['item'] = $this->fieldset()->getInstance();
         }
-
-        if (empty($options['publishable']) && !empty($options['item'])) {
-            $options['publishable'] = $options['item']->behaviours('Nos\Orm_Behaviour_Publishable');
-        }
-
-        if (!\Arr::get($options, 'allow_publish', false)) {
-            if (\Arr::get($options, 'publishable.options.allow_publish', false)) {
-                $options['allow_publish'] = \Config::processCallbackValue(\Arr::get($options, 'publishable.options.allow_publish'), true, $options['item']['item']);
-            } else {
-                // No configuration = it's allowed
-                $options['allow_publish'] = true;
-            }
-        }
-            
-        if (isset($options['populate']) && is_callable($options['populate'])) {
-            // The selected status may be forced to another via a standard 'populate' callback
-            $options['planification_status'] = call_user_func($options['populate'], $options['item']);
-        } else {
-            $options['planification_status'] = $options['item']->planificationStatus();
-        }
-
-        $options['planification_mode'] = !empty($options['publishable']['publication_start_property']) && !empty($options['publishable']['publication_end_property']);
-        $options['state_property'] = \Arr::get($options, 'publishable.publication_state_property', \Arr::get($options, 'publishable.publication_bool_property', ''));
-
-        $options['radio_options'] = \Arr::merge(array(
-            'no' => array(
-                'value'      => '0',
-                'content'    => '<img src="static/novius-os/admin/novius-os/img/icons/status-red.png" />',
-                'visible'    => !empty($options['state_property']),
-                'attributes' => array(
-                    'class'    => 'notransform',
-                    'id'       => uniqid('no_'),
-                    'disabled' => (!$options['allow_publish'] && $options['planification_status'] != 0) ? 'disabled' : false,
-                ),
-            ),
-            'planned' => array(
-                'value'      => '2',
-                'content'    => '<span class="ui-icon ui-icon-clock" />',
-                'visible'    => $options['planification_mode'],
-                'attributes' => array(
-                    'class'    => 'notransform',
-                    'id'       => uniqid('planned_'),
-                    'disabled' => !$options['allow_publish'] ? 'disabled' : false,
-                ),
-            ),
-            'yes' => array(
-                'value'      => '1',
-                'content'    => '<img src="static/novius-os/admin/novius-os/img/icons/status-green.png" />',
-                'visible'    => !empty($options['state_property']),
-                'attributes' => array(
-                    'class'    => 'notransform',
-                    'id'       => uniqid('yes_'),
-                    'disabled' => !$options['allow_publish'] ? 'disabled' : false,
-                ),
-            ),
-        ), \Arr::get($options, 'radio_options', array()));
-        
-        return $this->template((string) \View::forge($options['view'], $options, false));
+        return $this->template((string) \View::forge($this->renderer_options['view'], $this->renderer_options, false));
     }
 }

--- a/framework/views/renderer/publishable.view.php
+++ b/framework/views/renderer/publishable.view.php
@@ -10,8 +10,32 @@
 
 Nos\I18n::current_dictionary(array('nos::common'));
 
+if (empty($publishable) && !empty($item)) {
+    $publishable = $item->behaviours('Nos\Orm_Behaviour_Publishable');
+}
+
 if (empty($publishable)) {
     return;
+}
+
+if (!isset($allow_publish) || $allow_publish === null) {
+    if (isset($publishable['options']) && isset($publishable['options']['allow_publish'])) {
+        $allow_publish = \Config::processCallbackValue($publishable['options']['allow_publish'], true, $item['item']);
+    } else {
+        // No configuration = it's allowed
+        $allow_publish = true;
+    }
+}
+
+$state_property     = !empty($publishable['publication_state_property']) ? $publishable['publication_state_property'] : (!empty($publishable['publication_bool_property']) ? $publishable['publication_bool_property'] : '');
+$yes_no_mode        = ($state_property !== '');
+$planification_mode = !empty($publishable['publication_start_property']) && !empty($publishable['publication_end_property']);
+
+if (isset($populate) && is_callable($populate)) {
+    // The selected status may be forced to another via a standard 'populate' callback
+    $planification_status = call_user_func($populate, $item);
+} else {
+    $planification_status = $item->planificationStatus();
 }
 ?>
 <td class="c3">
@@ -39,8 +63,31 @@ if ($planification_mode) {
     echo '<span></span>';
 }
 ?>
-                <div style="width:<?= (empty($state_property) ? 0 : 50) + ($planification_mode ? 25 : 0) ?>px;">
+                <div style="width:<?= ($yes_no_mode ? 50 : 0) + ($planification_mode ? 25 : 0) ?>px;">
 <?php
+    $radio_options = \Arr::merge(array(
+        'no' => array(
+            'visible'    => $yes_no_mode,
+            'attributes' => array(
+                'id'       => uniqid('no_'),
+                'disabled' => (!$allow_publish && $planification_status != 0) ? 'disabled' : false,
+            ),
+        ),
+        'planned' => array(
+            'visible'    => $planification_mode,
+            'attributes' => array(
+                'id'       => uniqid('planned_'),
+                'disabled' => !$allow_publish ? 'disabled' : false,
+            ),
+        ),
+        'yes' => array(
+            'visible'    => $yes_no_mode,
+            'attributes' => array(
+                'id'       => uniqid('yes_'),
+                'disabled' => !$allow_publish ? 'disabled' : false,
+            ),
+        ),
+    ), $radio_options);
     foreach ($radio_options as $radio) {
         if (\Arr::get($radio, 'visible', true)) {
             echo \Form::radio($state_property, $radio['value'], $planification_status == $radio['value'], $radio['attributes']);

--- a/framework/views/renderer/publishable.view.php
+++ b/framework/views/renderer/publishable.view.php
@@ -10,32 +10,8 @@
 
 Nos\I18n::current_dictionary(array('nos::common'));
 
-if (empty($publishable) && !empty($item)) {
-    $publishable = $item->behaviours('Nos\Orm_Behaviour_Publishable');
-}
-
 if (empty($publishable)) {
     return;
-}
-
-if (!isset($allow_publish) || $allow_publish === null) {
-    if (isset($publishable['options']) && isset($publishable['options']['allow_publish'])) {
-        $allow_publish = \Config::processCallbackValue($publishable['options']['allow_publish'], true, $item['item']);
-    } else {
-        // No configuration = it's allowed
-        $allow_publish = true;
-    }
-}
-
-$state_property     = !empty($publishable['publication_state_property']) ? $publishable['publication_state_property'] : (!empty($publishable['publication_bool_property']) ? $publishable['publication_bool_property'] : '');
-$yes_no_mode        = ($state_property !== '');
-$planification_mode = !empty($publishable['publication_start_property']) && !empty($publishable['publication_end_property']);
-
-if (isset($populate) && is_callable($populate)) {
-    // The selected status may be forced to another via a standard 'populate' callback
-    $planification_status = call_user_func($populate, $item);
-} else {
-    $planification_status = $item->planificationStatus();
 }
 ?>
 <td class="c3">
@@ -63,40 +39,8 @@ if ($planification_mode) {
     echo '<span></span>';
 }
 ?>
-                <div style="width:<?= ($yes_no_mode ? 50 : 0) + ($planification_mode ? 25 : 0) ?>px;">
+                <div style="width:<?= (empty($state_property) ? 0 : 50) + ($planification_mode ? 25 : 0) ?>px;">
 <?php
-    $radio_options = \Arr::merge(array(
-        'no' => array(
-            'value'      => '0',
-            'content'    => '<img src="static/novius-os/admin/novius-os/img/icons/status-red.png" />',
-            'visible'    => $yes_no_mode,
-            'attributes' => array(
-                'class'    => 'notransform',
-                'id'       => uniqid('no_'),
-                'disabled' => (!$allow_publish && $planification_status != 0) ? 'disabled' : false,
-            ),
-        ),
-        'planned' => array(
-            'value'      => '2',
-            'content'    => '<span class="ui-icon ui-icon-clock" />',
-            'visible'    => $planification_mode,
-            'attributes' => array(
-                'class'    => 'notransform',
-                'id'       => uniqid('planned_'),
-                'disabled' => !$allow_publish ? 'disabled' : false,
-            ),
-        ),
-        'yes' => array(
-            'value'      => '1',
-            'content'    => '<img src="static/novius-os/admin/novius-os/img/icons/status-green.png" />',
-            'visible'    => $yes_no_mode,
-            'attributes' => array(
-                'class'    => 'notransform',
-                'id'       => uniqid('yes_'),
-                'disabled' => !$allow_publish ? 'disabled' : false,
-            ),
-        ),
-    ), $radio_options);
     foreach ($radio_options as $radio) {
         if (\Arr::get($radio, 'visible', true)) {
             echo \Form::radio($state_property, $radio['value'], $planification_status == $radio['value'], $radio['attributes']);


### PR DESCRIPTION
This refactors the renderer/publishable radio selectors to make it extensible.

It can be customized via a config array, wether by adding to the `renderer_options` (via an extended renderer and/or behaviour) or by overloading the `fields._publishable` key of a CRUD.

- The default selected value may be overloaded with a `populate` callback in the `renderer_options`
- The radio inputs are now created using `\Form::radio` instead of plain html. This allows it to be customized. As you can see in the diff, there is a big `radio_options` array. That way, anything related to the radio inputs can be customized.

Sample of possible configurations: 

```php
'fields' => [
	'_publishable' => [
		'renderer_options' => [
			'populate' => function ($item) use ($isUserAllowedToPublish) {
				$currentStatus = $item->planificationStatus();
				/* Do something to $currentStatus */
				return $someNewStatus;
			},
			'radio_options' => [
				'no' => [
					'visible' => $canSetStatus['0'],
				],
				'planned' => [
					'visible' => $isUserAllowedToPublish,
					'content' => 'This text will replace the clock icon.',
				],
				'yes' => [
					'visible' => $isUserAllowedToPublish,
					'attributes' => [
						'class' => 'some-cool-class',
						'readonly',
					],
				],
				'my_additional_custom_status' => [
					'value'      => '42',
					'content'    => 'Foo',
					'attributes' => array(
						'class' => 'notransform',
						'id'    => uniqid('foo_'),
					),
				],
			],
		],
	],
],
```