### PR TITLE
Added Foundation 6 styles for pagination + ability to have a different first page url

### DIFF
--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -77,6 +77,7 @@ if (!MBSTRING) {
         'Migrate' => FUEL_EXTEND_PATH.'migrate.php',
         'Module' => FUEL_EXTEND_PATH.'module.php',
         'ModuleNotFoundException' => FUEL_EXTEND_PATH.'module.php',
+        'Pagination' => FUEL_EXTEND_PATH.'pagination.php',
         'Profiler' => FUEL_EXTEND_PATH.'profiler.php',
         'Refine' => FUEL_EXTEND_PATH.'oil'.DIRECTORY_SEPARATOR.'refine.php',
         'Response' => FUEL_EXTEND_PATH.'response.php',

--- a/framework/classes/fuel/pagination.php
+++ b/framework/classes/fuel/pagination.php
@@ -29,4 +29,18 @@ class Pagination extends Fuel\Core\Pagination
 
         return parent::_make_link($page);
     }
+
+    public function render($raw = false)
+    {
+        // To avoid SEO duplicates, we set the canonical href (`foo.html` vs `foo.html?page=1`)
+        if ($this->config['calculated_page'] == 1 && !empty($this->config['pagination_url_first_page'])) {
+            $url = str_replace('{page}', $this->config['calculated_page'], $this->config['pagination_url_first_page']);
+            $mainController = \Nos\Nos::main_controller();
+            if (!empty($mainController)) {
+                $mainController->addMeta('<link rel="canonical" href="'.e($url).'">');
+            }
+        }
+
+        return parent::render($raw);
+    }
 }

--- a/framework/classes/fuel/pagination.php
+++ b/framework/classes/fuel/pagination.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2011 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link http://www.novius-os.org
+ */
+
+class Pagination extends Fuel\Core\Pagination
+{
+    public function __construct($config = array())
+    {
+        // Making sure our custom config key exists
+        $this->config['pagination_url_first_page'] = null;
+        parent::__construct($config);
+    }
+
+    protected function _make_link($page)
+    {
+        // Making sure we have a valid page number
+        empty($page) and $page = 1;
+
+        // The first page url may be specific to avoid SEO duplicates (`foo.html` vs `foo.html?page=1`)
+        if ($page == 1 && !empty($this->config['pagination_url_first_page'])) {
+            return str_replace('{page}', $page, $this->config['pagination_url_first_page']);
+        }
+
+        return parent::_make_link($page);
+    }
+}

--- a/framework/config/pagination.config.php
+++ b/framework/config/pagination.config.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2011 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link http://www.novius-os.org
+ */
+
+Nos\I18n::current_dictionary(array('nos::pagination'));
+
+return array(
+    'foundation6' => array(
+        'wrapper'                 => '
+            <nav>
+                <ul class="pagination" role="navigation" aria-label="'.e(__('Pagination')).'">
+                    {pagination}
+                </ul>
+            </nav>
+        ',
+
+        'first'                   => '<li class="pagination-first">{link}</li>',
+        'first-marker'            => e(__('First')),
+        'first-link'              => '<a href="{uri}" aria-label="'.e(__('First page')).'">{page}</a>',
+
+        'first-inactive'          => '<li class="pagination-first disabled">{link}</li>',
+        'first-inactive-link'     => '{page}',
+
+        'previous'                => '<li class="pagination-previous">{link}</li>',
+        'previous-marker'         => e(__('Previous')),
+        'previous-link'           => '<a href="{uri}" rel="prev" aria-label="'.e(__('Previous page (page {page})')).'">{page}</a>',
+
+        'previous-inactive'       => '<li class="pagination-previous disabled">{link}</li>',
+        'previous-inactive-link'  => '{page}',
+
+        'regular'                 => '<li>{link}</li>',
+        'regular-link'            => '<a href="{uri}" aria-label="'.e(__('Page {page}')).'">{page}</a>',
+
+        'active'                  => '<li class="current">{link}</li>',
+        'active-link'             => '{page}',
+
+        'next'                    => '<li class="pagination-next">{link}</li>',
+        'next-marker'             => e(__('Next')),
+        'next-link'               => '<a href="{uri}" rel="next" aria-label="'.e(__('Next page (page {page})')).'">{page}</a>',
+
+        'next-inactive'           => '<li class="pagination-next disabled">{link}</li>',
+        'next-inactive-link'      => '{page}',
+
+        'last'                    => '<li class="pagination-last">{link}</li>',
+        'last-marker'             => e(__('Last')),
+        'last-link'               => '<a href="{uri}" aria-label="'.e(__('Last page (page {page})')).'">{page}</a>',
+
+        'last-inactive'           => '<li class="pagination-last disabled">{link}</li>',
+        'last-inactive-link'      => '{page}',
+    ),
+);

--- a/framework/lang/fr/pagination.lang.php
+++ b/framework/lang/fr/pagination.lang.php
@@ -1,0 +1,14 @@
+<?php
+
+return array(
+    'Pagination'                  => 'Pagination',
+    'First'                       => 'Première',
+    'First page'                  => 'Première page',
+    'Previous'                    => 'Précédente',
+    'Previous page (page {page})' => 'Page précédente (page {page})',
+    'Page {page}'                 => 'Page {page}',
+    'Next'                        => 'Suivante',
+    'Next page (page {page})'     => 'Page suivante (page {page})',
+    'Last'                        => 'Dernière',
+    'Last page (page {page})'     => 'Dernière page (page {page})',
+);


### PR DESCRIPTION
The different first page url is needed to avoid SEO duplicates between `foo.html` and `foo.html?page=1`.

Since I can't just hardcode it to avoid breaking backward compatibility, I just added an option that easily allows to enable this option in the standard configuration array.