### PR TITLE
Fix User Configuration Unserialization

### DIFF
--- a/framework/applications/noviusos_user/classes/model/user.model.php
+++ b/framework/applications/noviusos_user/classes/model/user.model.php
@@ -251,8 +251,13 @@ class Model_User extends \Nos\Orm\Model
     {
         if (!$this->user_configuration) {
             return array();
-        } else {
-            return unserialize($this->user_configuration);
         }
+
+        $userConfiguration = unserialize($this->user_configuration);
+        if (!is_array($userConfiguration)) {
+            return array();
+        }
+
+        return $userConfiguration;
     }
 }


### PR DESCRIPTION
If `$this->user_configuration` contains an invalid serialized string, we have to return an empty array.