### PR TITLE
Adding classes namespace during application's installation

### DIFF
--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -417,7 +417,7 @@ class Application
 
         // Load application' classes namespaces to use these in migrations
         $applicationPath = static::get_application_path($this->folder);
-        if (is_dir($applicationPath) && is_dir($applicationPath.'/classes/')) {
+        if ($applicationPath !== false && is_dir($applicationPath.'/classes/')) {
             \Autoloader::add_namespace($new_metadata['namespace'], $applicationPath.'/classes/');
         }
 

--- a/framework/classes/application.php
+++ b/framework/classes/application.php
@@ -415,6 +415,12 @@ class Application
             $this->symlink('static') && $this->symlink('htdocs');
         }
 
+        // Load application' classes namespaces to use these in migrations
+        $applicationPath = static::get_application_path($this->folder);
+        if (is_dir($applicationPath) && is_dir($applicationPath.'/classes/')) {
+            \Autoloader::add_namespace($new_metadata['namespace'], $applicationPath.'/classes/');
+        }
+
         // Cache the metadata used to install the application
         $config['app_installed'] = static::$rawAppInstalled;
         $config['app_installed'][$this->folder] = $new_metadata;


### PR DESCRIPTION
Migrations can now uses classes with application namespace.