### PR TITLE
Removes the possibility to disable cache via the _cache query arg

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -116,11 +116,10 @@ class Controller_Front extends Controller
         }
 
         // POST or preview means no cache. Ever.
-        // We don't want cache in DEV except if _cache=1
         if ($this->_is_preview || \Input::method() == 'POST') {
             $this->_use_cache = false;
         } else {
-            $this->_use_cache = \Input::get('_cache', \Config::get('novius-os.cache', true));
+            $this->_use_cache = \Config::get('novius-os.cache', true);
         }
 
         \Event::trigger('front.start');


### PR DESCRIPTION
Removes the possibility to disable the cache via the `_cache` query argument. This could be exploited by attackers for DDOS purposes.

There seems to be no usage of this parameter. An alternative for debugging is to use  the `_preview` parameter (which requires to be logged in admin).

An alternative to this PR would be to use this parameter only if logged in admin (like for the `_preview` parameter).