### PR TITLE
Allows to duplicate a menu from application menu

### DIFF
--- a/framework/applications/noviusos_menu/classes/controller/admin/menu/crud.ctrl.php
+++ b/framework/applications/noviusos_menu/classes/controller/admin/menu/crud.ctrl.php
@@ -120,7 +120,7 @@ class Controller_Admin_Menu_Crud extends Controller_Admin_Crud
         return strtr($return, $replaces);
     }
 
-    public function action_duplicate($id = null)
+    public function action_duplicate($id)
     {
         try {
             /**

--- a/framework/applications/noviusos_menu/classes/controller/admin/menu/crud.ctrl.php
+++ b/framework/applications/noviusos_menu/classes/controller/admin/menu/crud.ctrl.php
@@ -12,6 +12,7 @@ namespace Nos\Menu;
 
 use Nos\Controller_Admin_Crud;
 use Nos\User\Permission;
+use Nos\Nos;
 
 class Controller_Admin_Menu_Crud extends Controller_Admin_Crud
 {
@@ -134,7 +135,7 @@ class Controller_Admin_Menu_Crud extends Controller_Admin_Crud
             }
             // If only one context is active popup will not be shown
             if (count($contexts) === 1 || !empty($duplicateContext)) {
-                $context = !empty($duplicateContext) ? $duplicateContext : $menu->menu_context;
+                $context = !empty($duplicateContext) ? $duplicateContext : Nos::main_controller()->getContext();
                 $menu->duplicate($context);
                 // Send response
                 \Response::json(array(
@@ -143,7 +144,7 @@ class Controller_Admin_Menu_Crud extends Controller_Admin_Crud
                         'action' => 'insert',
                         'context' => $context,
                     ),
-                    'notify' => __('Here you are ! The menu has just been duplicated.'),
+                    'notify' => __('Here you are! The menu has just been duplicated.'),
                 ));
             } else {
                 \Response::json(array(

--- a/framework/applications/noviusos_menu/classes/model/menu.model.php
+++ b/framework/applications/noviusos_menu/classes/model/menu.model.php
@@ -186,7 +186,9 @@ class Model_Menu extends Model
         $try = 1;
         do {
             try {
-                $title_append = __(' (copy)');
+                $title_append = strtr(__(' (copy {{count}})'), array(
+                    '{{count}}' => $try,
+                ));
                 $clone->menu_title = $this->title_item().$title_append;
                 $clone->menu_context = $targetContext;
                 $clone->menu_context_common_id = $clone->menu_id;

--- a/framework/applications/noviusos_menu/classes/model/menu.model.php
+++ b/framework/applications/noviusos_menu/classes/model/menu.model.php
@@ -10,7 +10,6 @@
 
 namespace Nos\Menu;
 
-use Fuel\Core\Log;
 use Nos\Orm\Model;
 use Nos\Page\Model_Page;
 

--- a/framework/applications/noviusos_menu/classes/model/menu/item.model.php
+++ b/framework/applications/noviusos_menu/classes/model/menu/item.model.php
@@ -11,6 +11,7 @@
 namespace Nos\Menu;
 
 use Nos\Orm\Model;
+use Nos\Menu\Model_Menu_Item_Attribute;
 
 class Model_Menu_Item extends Model
 {
@@ -177,5 +178,26 @@ class Model_Menu_Item extends Model
             }
             throw $e;
         }
+    }
+
+    /**
+     * @param Model_Menu $menu : The original menu, items will duplicate FROM
+     * @param Model_Menu $duplicatedMenu : The duplicated menu, fields will duplicate TO
+     * @param null $cloned_mitem_parent_id
+     */
+    public function duplicate(Model_Menu_Item $item, Model_Menu $duplicatedMenu, $cloned_mitem_parent_id)
+    {
+        $clone = clone $item;
+        $clone->mitem_menu_id = $duplicatedMenu->menu_id;
+        $clone->mitem_parent_id = $cloned_mitem_parent_id;
+
+        if ($clone->save()) {
+            $itemsAttributes = $item->attributes;
+            foreach ($itemsAttributes as $attribute) {
+                $attribute->duplicate($attribute, $clone->mitem_id);
+            }
+        };
+
+        return $clone;
     }
 }

--- a/framework/applications/noviusos_menu/classes/model/menu/item.model.php
+++ b/framework/applications/noviusos_menu/classes/model/menu/item.model.php
@@ -11,7 +11,6 @@
 namespace Nos\Menu;
 
 use Nos\Orm\Model;
-use Nos\Menu\Model_Menu_Item_Attribute;
 
 class Model_Menu_Item extends Model
 {

--- a/framework/applications/noviusos_menu/classes/model/menu/item.model.php
+++ b/framework/applications/noviusos_menu/classes/model/menu/item.model.php
@@ -195,7 +195,7 @@ class Model_Menu_Item extends Model
             foreach ($itemsAttributes as $attribute) {
                 $attribute->duplicate($attribute, $clone->mitem_id);
             }
-        };
+        }
 
         return $clone;
     }

--- a/framework/applications/noviusos_menu/classes/model/menu/item/attribute.model.php
+++ b/framework/applications/noviusos_menu/classes/model/menu/item/attribute.model.php
@@ -40,4 +40,15 @@ class Model_Menu_Item_Attribute extends Model
             'null' => false,
         ),
     );
+
+    /**
+     * @param Model_Menu_Item $item : The original item, attributes will duplicate FROM
+     * @param integer $duplicatedItemId
+     */
+    public function duplicate(Model_Menu_Item_Attribute $attribute, $duplicatedItemId)
+    {
+        $clone = clone $attribute;
+        $clone->miat_mitem_id = $duplicatedItemId;
+        $clone->save();
+    }
 }

--- a/framework/applications/noviusos_menu/config/common/menu.config.php
+++ b/framework/applications/noviusos_menu/config/common/menu.config.php
@@ -57,5 +57,19 @@ return array(
         'add' => array(
             'label' => __('Add a menu'),
         ),
+        'duplicate' => array(
+            'action' => array(
+                'action' => 'nosAjax',
+                'params' => array(
+                    'url' => '{{controller_base_url}}duplicate/{{_id}}',
+                ),
+            ),
+            'label' => __('Duplicate'),
+            'primary' => false,
+            'icon' => 'circle-plus',
+            'targets' => array(
+                'grid' => true,
+            ),
+        ),
     ),
 );

--- a/framework/applications/noviusos_menu/lang/fr/common.lang.php
+++ b/framework/applications/noviusos_menu/lang/fr/common.lang.php
@@ -247,7 +247,7 @@ return array(
 
     'or' => 'ou',
 
-    '(copy)' => '(copie)',
+    ' (copy {{count}})' => ' (copie {{count}})',
 
     'Cancel' => 'Fermer',
 );

--- a/framework/applications/noviusos_menu/lang/fr/common.lang.php
+++ b/framework/applications/noviusos_menu/lang/fr/common.lang.php
@@ -237,7 +237,7 @@ return array(
 
     'You\'ve already duplicated this menu 5 times. Edit them before creating more duplications.' => 'Vous avez dupliqué ce menu cinq fois. Modifiez les copies existantes avant d\'en créer de nouvelles .',
 
-    'Here you are ! The menu has just been duplicated.' => 'Le menu a bien été dupliqué.',
+    'Here you are! The menu has just been duplicated.' => 'Le menu a bien été dupliqué.',
 
     'Duplicating the menu "{{title}}"' => 'Duplication du menu "{{title}}"',
 

--- a/framework/applications/noviusos_menu/lang/fr/common.lang.php
+++ b/framework/applications/noviusos_menu/lang/fr/common.lang.php
@@ -235,4 +235,19 @@ return array(
     #: views/admin/renderer/menu/items.view.php:18
     'Delete this item' => 'Supprimer cet item',
 
+    'You\'ve already duplicated this menu 5 times. Edit them before creating more duplications.' => 'Vous avez dupliqué ce menu cinq fois. Modifiez les copies existantes avant d\'en créer de nouvelles .',
+
+    'Here you are ! The menu has just been duplicated.' => 'Le menu a bien été dupliqué.',
+
+    'Duplicating the menu "{{title}}"' => 'Duplication du menu "{{title}}"',
+
+    'Duplication target :' => 'Cible de la duplication :',
+
+    'Duplicate' => 'Dupliquer',
+
+    'or' => 'ou',
+
+    '(copy)' => '(copie)',
+
+    'Cancel' => 'Fermer',
 );

--- a/framework/applications/noviusos_menu/lang/ja/common.lang.php
+++ b/framework/applications/noviusos_menu/lang/ja/common.lang.php
@@ -230,4 +230,5 @@ return array(
     #: views/admin/renderer/menu/items.view.php:18
     'Delete this item' => 'アイテムを削除',
 
+    ' (copy {{count}})' => ' (複製 {{count}})',
 );

--- a/framework/applications/noviusos_menu/views/admin/popup_duplicate.view.php
+++ b/framework/applications/noviusos_menu/views/admin/popup_duplicate.view.php
@@ -17,7 +17,7 @@ $id = $uniqid = uniqid('form_');
             $site = \Nos\Tools_Context::site($context);
             ?>
             <input type="radio" name="duplicate_context"
-                   value="<?= $context ?>" <?= $item->menu_context === $context ? 'checked' : '' ?> />
+                   value="<?= $context ?>" <?= $item->getContext() === $context ? 'checked' : '' ?> />
             <?= \Nos\Tools_Context::contextLabel($context, array('short' => false, )) ?>
         </label>
         <br/>

--- a/framework/applications/noviusos_menu/views/admin/popup_duplicate.view.php
+++ b/framework/applications/noviusos_menu/views/admin/popup_duplicate.view.php
@@ -1,0 +1,66 @@
+<?php
+
+\Nos\I18n::current_dictionary('noviusos_menu::common', 'nos::common');
+
+$id = $uniqid = uniqid('form_');
+
+?>
+<form class="fieldset standalone" id="<?= $id ?>">
+    <p>
+        <strong>
+            <?= __('Duplication target :') ?>
+        </strong>
+    </p>
+    <?php foreach ($contexts_list as $context): ?>
+        <label>
+            <?php
+            $site = \Nos\Tools_Context::site($context);
+            ?>
+            <input type="radio" name="duplicate_context"
+                   value="<?= $context ?>" <?= $item->menu_context === $context ? 'checked' : '' ?> />
+            <?= \Nos\Tools_Context::contextLabel($context, array('short' => false,)) ?>
+        </label>
+        <br/>
+    <?php endforeach; ?>
+    <p style="margin: 1em 0;">
+        <button type="submit" class="ui-priority-primary ui-state-default">
+            <?= __('Duplicate') ?>
+        </button>
+        <span>
+            <?= __('or') ?>
+        </span>
+        <a href="#">
+            <?= __('Cancel') ?>
+        </a>
+    </p>
+</form>
+<script type="text/javascript">
+    require(['jquery-nos'],
+        function ($) {
+            $(function () {
+                var $form = $('#<?= $id ?>'),
+                    $confirmButton = $form.find(':submit'),
+                    $cancelButton = $form.find('a:last');
+
+                $form.nosFormUI();
+
+                $confirmButton.click(function (e) {
+                    e.preventDefault();
+                    if ($(this).hasClass('ui-state-disabled')) {
+                        return;
+                    }
+                    $form.nosAjax({
+                        url: <?= \Format::forge($action)->to_json() ?>,
+                        method: 'POST',
+                        data: $form.serialize()
+                    });
+                    $form.nosDialog('close');
+                });
+
+                $cancelButton.click(function (e) {
+                    e.preventDefault();
+                    $form.nosDialog('close');
+                });
+            });
+        });
+</script>

--- a/framework/applications/noviusos_menu/views/admin/popup_duplicate.view.php
+++ b/framework/applications/noviusos_menu/views/admin/popup_duplicate.view.php
@@ -18,7 +18,7 @@ $id = $uniqid = uniqid('form_');
             ?>
             <input type="radio" name="duplicate_context"
                    value="<?= $context ?>" <?= $item->menu_context === $context ? 'checked' : '' ?> />
-            <?= \Nos\Tools_Context::contextLabel($context, array('short' => false,)) ?>
+            <?= \Nos\Tools_Context::contextLabel($context, array('short' => false, )) ?>
         </label>
         <br/>
     <?php endforeach; ?>


### PR DESCRIPTION
The idea is to propose to users the ability to duplicate a menu. 
On duplication a popin shows giving the user the ability to select one or many context.

:warning: The duplicated menues wont be considered as translations and will all be independants.

![capture d ecran_2017-11-09_09-49-15](https://user-images.githubusercontent.com/5948150/32596348-471ee974-c533-11e7-9bd6-c6a935dfa402.png)
