### PR TITLE
Use `crypto_mac` key instead of `hmac` in frontcache

### DIFF
--- a/framework/classes/frontcache.php
+++ b/framework/classes/frontcache.php
@@ -58,7 +58,7 @@ class FrontCache
             return static::$_php_begin;
         }
         \Config::load('crypt', true);
-        static::$_php_begin = md5(\Config::get('crypt.hmac').'begin');
+        static::$_php_begin = md5(\Config::get('crypt.crypto_hmac').'begin');
         return static::$_php_begin;
     }
 


### PR DESCRIPTION
Currently, when `$_php_begin` is generated, it uses the `hmac` key from `local/config/crypt.config.php`.

It's probably a typo, as the automatically generated config contains `crypto_hmac`, but no `hmac` key (see https://github.com/novius-os/fuelphp-core/blob/1.7/master/classes/crypt.php#L56)

This leads to `$_php_begin` always having the same value (`md5('begin') = '8d589afa4dfaeeed85fff5aa78e5ff6a'`)


