### PR TITLE
Redirects enhanced URLs ending with a slash

### DIFF
--- a/framework/classes/controller/front.ctrl.php
+++ b/framework/classes/controller/front.ctrl.php
@@ -394,6 +394,14 @@ class Controller_Front extends Controller
     }
 
     /**
+     * @return string Current relative URL.
+     */
+    public function getRelativeUrl()
+    {
+        return $this->_url;
+    }
+
+    /**
      * @return string Relative (to getContextUrl()) URL of the current page.
      */
     public function getPageUrl()

--- a/framework/classes/controller/front/application.ctrl.php
+++ b/framework/classes/controller/front/application.ctrl.php
@@ -24,6 +24,14 @@ class Controller_Front_Application extends Controller
     {
         $this->main_controller = Nos::main_controller();
 
+        // Permanently redirects URLs ending with a slash or with a slash followed by .html
+        if (\Config::get('novius-os.redirect_urlenhancer_trailing_slash', false)) {
+            if (preg_match('`/(\.html)?$`', $this->main_controller->getRelativeUrl(), $match)) {
+                $urlWithHtmlExtension = \Str::sub($this->main_controller->getRelativeUrl(), 0, -\Str::length($match[0])).'.html';
+                \Response::redirect($urlWithHtmlExtension, 'location', 301);
+            }
+        }
+
         return parent::before();
     }
 

--- a/framework/config/config.php
+++ b/framework/config/config.php
@@ -288,6 +288,11 @@ return array(
         
         'enable_url_enhancers_on_root_pages' => false,
 
+        /**
+         * Whether to redirect an enhanced URL with a trailing slash to the same URL with an .html extension.
+         */
+        'redirect_urlenhancer_trailing_slash_to_html' => false,
+
         'finder_paths' => array(
             APPPATH,
             NOSPATH,


### PR DESCRIPTION
For an URL enhancer, all these URLs will work and return the same content :

http://example.org/my-url-enhancer.html
http://example.org/my-url-enhancer/
http://example.org/my-url-enhancer/.html

The purpose of this PR is to avoid duplicate URLs by redirecting the last two to the first one.

To make it work, you'll have to enable this feature in `novius-os/framework/config/config.php` :
```php
'redirect_urlenhancer_trailing_slash_to_html' => true,
```

