### PR TITLE
Redirects URLs ending with a slash only in front office

### DIFF
--- a/framework/classes/controller/front/application.ctrl.php
+++ b/framework/classes/controller/front/application.ctrl.php
@@ -24,8 +24,8 @@ class Controller_Front_Application extends Controller
     {
         $this->main_controller = Nos::main_controller();
 
-        // Permanently redirects URLs ending with a slash or with a slash followed by .html
-        if (\Config::get('novius-os.redirect_urlenhancer_trailing_slash', false)) {
+        // Permanently redirects URLs ending with a slash or with a slash followed by .html in front office
+        if (NOS_ENTRY_POINT === 'front' && \Config::get('novius-os.redirect_urlenhancer_trailing_slash', false)) {
             if (preg_match('`/(\.html)?$`', $this->main_controller->getRelativeUrl(), $match)) {
                 $urlWithHtmlExtension = \Str::sub($this->main_controller->getRelativeUrl(), 0, -\Str::length($match[0])).'.html';
                 \Response::redirect($urlWithHtmlExtension, 'location', 301);


### PR DESCRIPTION
If the main controller is not `Controller_Front`, it may throw an error because the method `getRelativeUrl` may not exists.

This is the case when previewing an enhancer in a page CRUD which calls the front controller of the enhancer via an hmvc call, thus the main controller is `Controller_Admin_Page` :

> Fatal Error - Call to undefined method Nos\Page\Controller_Admin_Page::getRelativeUrl()

An alternative to this fix could be to test if the method exists on the main controller.