### PR TITLE
Trigger event after page duplication

### DIFF
--- a/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
+++ b/framework/applications/noviusos_page/classes/controller/admin/page.ctrl.php
@@ -400,6 +400,8 @@ class Controller_Admin_Page extends \Nos\Controller_Admin_Crud
             }
         }
 
+        \Event::trigger_function('page.afterDuplicate', array($item, &$clone));
+
         return $common_id;
     }
 }


### PR DESCRIPTION
# Current issue:
When duplicating a page, if it has custom relations, those won't be duplicated and we'll have to recreate it by hand.

# Suggested fix:
Instead of a big evolution that will handle every single specific case, triggering an event after a page  duplication allow devs to define any behaviour they want  (IE perform a deep cloning of the page custom relations) .

The event has two arguments, `$item` being the original page and `$clone` wich is a reference to the new duplicated page. 
